### PR TITLE
Group analysis and clarification for pre/post epochs

### DIFF
--- a/modules/power_explorer/R/aaa-presets.R
+++ b/modules/power_explorer/R/aaa-presets.R
@@ -484,7 +484,7 @@ build_epoch_loader <- function (id = "loader_epoch_name", varname = "epoch_choic
           choices = c(value, ""), selected = value, multiple = FALSE)
       ),
       shidashi::flex_break(),
-      shidashi::flex_item(shiny::p("Pre must be negative if you need a pre-stimulus baseline window."), size=2),
+      shidashi::flex_item(shiny::p("Pre must be negative if you need a pre-event baseline window."), size=2),
       shidashi::flex_break(),
       shidashi::flex_item(shiny::numericInput(inputId = comp$get_sub_element_id("trial_starts",
         with_namespace = TRUE), label = "Pre", min = -10, step = .1,

--- a/modules/power_explorer/R/aaa-presets.R
+++ b/modules/power_explorer/R/aaa-presets.R
@@ -9,18 +9,18 @@ if(getOption("rave.run.if_false", FALSE)){
 
 ### custom 3dViewer during data load screen
 get_loader_3dviewer <- function (id = "loader_3d_viewer", height = "100%", loader_project_id = "loader_project_name",
-          loader_subject_id = "loader_subject_code", loader_reference_id = "loader_reference_name",
-          loader_electrodes_id = "loader_electrode_text", gadgets = c("standalone",
-                                                                      "download"))
+  loader_subject_id = "loader_subject_code", loader_reference_id = "loader_reference_name",
+  loader_electrodes_id = "loader_electrode_text", gadgets = c("standalone",
+    "download"))
 {
   comp <- ravedash:::RAVEShinyComponent$new(id = id)
   comp$depends <- c(loader_project_id, loader_subject_id, loader_electrodes_id,
-                    loader_reference_id)
+    loader_reference_id)
   comp$no_save <- TRUE
   gadgets <- gadgets[gadgets %in% c("standalone", "download2")]
   comp$ui_func <- function(id, value, depends) {
     ravedash::output_gadget_container(threeBrain::threejsBrainOutput(outputId = id,
-                                                           height = height, reportSize = FALSE), gadgets = gadgets)
+      height = height, reportSize = FALSE), gadgets = gadgets)
   }
   comp$server_func <- function(input, output, session) {
     tools <- ravedash::register_rave_session(session)
@@ -39,9 +39,9 @@ get_loader_3dviewer <- function (id = "loader_3d_viewer", height = "100%", loade
       electrodes_text <- loader_electrodes$current_value
       reference_name <- loader_reference$current_value
       brain <- comp$container$get_cache("loader_subject_brain",
-                                        default = NULL)
+        default = NULL)
       if (!inherits(brain, "rave-brain") || !identical(brain$subject_code,
-                                                       subject_code)) {
+        subject_code)) {
         ravedash::logger("Re-generate loader's brain", level = "trace")
         brain <- raveio::rave_brain(subject, surfaces = "pial")
       }
@@ -49,7 +49,7 @@ get_loader_3dviewer <- function (id = "loader_3d_viewer", height = "100%", loade
         ravedash::logger("Using cached loader's brain", level = "trace")
       }
       comp$container$set_cache(key = "loader_subject_brain",
-                               value = brain, expire_after = 100)
+        value = brain, expire_after = 100)
       if (is.null(brain)) {
         return()
       }
@@ -62,19 +62,19 @@ get_loader_3dviewer <- function (id = "loader_3d_viewer", height = "100%", loade
       val <- rep("Not Loading", length(all_electrodes))
       val[all_electrodes %in% electrodes] <- "Excluded"
       val[all_electrodes %in% electrodes & all_electrodes %in%
-            valid_electrodes] <- "Loading"
+          valid_electrodes] <- "Loading"
       val <- factor(val, levels = c("Loading", "Excluded",
-                                    "Not Loading"))
+        "Not Loading"))
       tbl <- data.frame(Subject = subject$subject_code,
-                        Electrode = subject$electrodes, Value = val)
+        Electrode = subject$electrodes, Value = val)
       tbl
     }), loader_project$current_value, loader_subject$current_value,
-    loader_electrodes$current_value, loader_reference$current_value,
-    ignoreNULL = TRUE, ignoreInit = TRUE)
+      loader_electrodes$current_value, loader_reference$current_value,
+      ignoreNULL = TRUE, ignoreInit = TRUE)
     viewer <- shiny::bindEvent(shiny::bindCache(shiny::reactive({
       shiny::invalidateLater(500)
       brain <- comp$container$get_cache("loader_subject_brain",
-                                        default = NULL)
+        default = NULL)
       if (!inherits(brain, "rave-brain")) {
         return()
       }
@@ -85,54 +85,30 @@ get_loader_3dviewer <- function (id = "loader_3d_viewer", height = "100%", loade
       theme <- shidashi::get_theme(tools$theme_event)
       ravedash::logger("Re-generate loader's viewer", level = "trace")
       wg <- brain$plot(volumes = FALSE, start_zoom = 1,
-                       atlases = FALSE, side_canvas = FALSE, control_display = FALSE,
-                       background = theme$background, palettes = list(Value = c("orange",
-                                                                                "pink", "gray30")),
-                       controllers = list(`Background Color` = theme$background,
-                       `Show Time` = FALSE))
+        atlases = FALSE, side_canvas = FALSE, control_display = FALSE,
+        background = theme$background, palettes = list(Value = c("orange",
+          "pink", "gray30")),
+        controllers = list(`Background Color` = theme$background,
+          `Show Time` = FALSE))
       wg
     }), shidashi::get_theme(tools$theme_event), electrode_table(),
-    cache = "session"), shidashi::get_theme(tools$theme_event),
-    electrode_table(), ignoreNULL = TRUE)
+      cache = "session"), shidashi::get_theme(tools$theme_event),
+      electrode_table(), ignoreNULL = TRUE)
     ravedash::register_output(shiny::bindEvent(threeBrain::renderBrain({
       wg <- viewer()
       shiny::validate(shiny::need(!is.null(wg), message = ""))
       return(wg)
     }), viewer(), ignoreNULL = FALSE, ignoreInit = FALSE),
-    outputId = "loader_3d_viewer", export_type = "3dviewer",
-    session = session)
+      outputId = "loader_3d_viewer", export_type = "3dviewer",
+      session = session)
   }
   comp
 }
 
-
-
-
-
-
-component_container <- ravedash:::RAVEShinyComponentContainer$new(
-  module_id = module_id, pipeline_name = pipeline$pipeline_name
-)
-
-
-# Define components
-loader_project <- ravedash::presets_loader_project()
-loader_subject <- ravedash::presets_loader_subject()
-loader_epoch <- ravedash::presets_loader_epoch()
-loader_electrodes <- ravedash::presets_loader_electrodes()
-loader_reference <- ravedash::presets_loader_reference()
-loader_viewer <- get_loader_3dviewer()#ravedash::presets_loader_3dviewer(height = "100%")
-
-
-str(loader_viewer$get_settings_value)
-
-
-import_export_pipeline <- ravedash::presets_import_export_subject_pipeline()
-
 build_electrode_selector <- function (id = "electrode_text", varname = "analysis_electrodes",
-                                      label = "Select Electrodes", loader_project_id = "loader_project_name",
-                                      loader_subject_id = "loader_subject_code", pipeline_repository = "repository",
-                                      start_simple = FALSE, multiple = TRUE)
+  label = "Select Electrodes", loader_project_id = "loader_project_name",
+  loader_subject_id = "loader_subject_code", pipeline_repository = "repository",
+  start_simple = FALSE, multiple = TRUE)
 {
   comp <- ravedash:::RAVEShinyComponent$new(id = id, varname = varname)
   comp$depends <- c(loader_project_id, loader_subject_id)
@@ -146,13 +122,13 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
   btn_previous_str <- "previous"
   btn_next_str <- "next"
   css_class_optional <- ifelse(start_simple, "rave-optional soft-hidden",
-                               "rave-optional")
+    "rave-optional")
   comp$no_save <- c(reset_str, category_choices_str, selected_electrode_text_str,
-                    btn_previous_str, btn_next_str)
+    btn_previous_str, btn_next_str)
   get_repo <- function() {
     if (!comp$container$data[["@has"]](pipeline_repository)) {
       repository <- raveio::pipeline_read(var_names = pipeline_repository,
-                                          pipe_dir = comp$container$pipeline_path)
+        pipe_dir = comp$container$pipeline_path)
       comp$container$data[[pipeline_repository]] <- repository
     }
     else {
@@ -172,40 +148,40 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
     return(NULL)
   }
   get_default <- function(sub_id, missing = NULL, use_cache = TRUE,
-                          constraint = NULL) {
+    constraint = NULL) {
     vname <- comp$get_sub_element_varnames(sub_id)
     subject <- get_subject()
     if (inherits(subject, "RAVESubject")) {
       missing <- subject$get_default(vname, default_if_missing = missing,
-                                     simplify = TRUE)
+        simplify = TRUE)
     }
     comp$get_settings_value(use_cache = use_cache, default = missing,
-                            key = vname, constraint = constraint)
+      key = vname, constraint = constraint)
   }
   comp$ui_func <- function(id, value, depends) {
     ravedash::input_card(class_header = "shidashi-anchor",
-               href = ravedash::card_href(label, type = "input", module_id = comp$container$module_id),
-               title = shiny::tagList(label, " ", shiny::textOutput(comp$get_sub_element_id(selected_electrode_text_str,
-                                                                                            with_namespace = TRUE), inline = TRUE, shiny::tags$small)),
-               shiny::selectInput(inputId = comp$get_sub_element_id(category_str,
-                                                                    with_namespace = TRUE), label = "Electrode categories",
-                                  choices = ""),
-               shiny::selectInput(inputId = comp$get_sub_element_id(category_choices_str,
-                                                                    with_namespace = TRUE), label = "Category levels (multi-select)", choices = "",
-                                  multiple = TRUE)
-               ,
-               shiny::textInput(inputId = id, label = "Select electrode by number",
-                                value = "", placeholder = "E.g. 1-30,55-60,88")
-               ,
-               shiny::div(class = "form-group", shiny::actionLink(inputId = comp$get_sub_element_id(reset_str,
-                                                                                                    with_namespace = TRUE), label = "Reset electrode selectors")),
-               shiny::div(class = "form-group", shiny::downloadLink(outputId = comp$get_sub_element_id(download_str,
-                                                                                                       with_namespace = TRUE), label = "Download copy of meta data for all electrodes"))
+      href = ravedash::card_href(label, type = "input", module_id = comp$container$module_id),
+      title = shiny::tagList(label, " ", shiny::textOutput(comp$get_sub_element_id(selected_electrode_text_str,
+        with_namespace = TRUE), inline = TRUE, shiny::tags$small)),
+      shiny::selectInput(inputId = comp$get_sub_element_id(category_str,
+        with_namespace = TRUE), label = "Electrode categories",
+        choices = ""),
+      shiny::selectInput(inputId = comp$get_sub_element_id(category_choices_str,
+        with_namespace = TRUE), label = "Category levels (multi-select)", choices = "",
+        multiple = TRUE)
+      ,
+      shiny::textInput(inputId = id, label = "Select electrode by number",
+        value = "", placeholder = "E.g. 1-30,55-60,88")
+      ,
+      shiny::div(class = "form-group", shiny::actionLink(inputId = comp$get_sub_element_id(reset_str,
+        with_namespace = TRUE), label = "Reset electrode selectors")),
+      shiny::div(class = "form-group", shiny::downloadLink(outputId = comp$get_sub_element_id(download_str,
+        with_namespace = TRUE), label = "Download copy of meta data for all electrodes"))
     )
   }
   comp$server_func <- function(input, output, session) {
     comp$ready_to_collect <- function() {
-      shiny::isolate(isFALSE(watch_loader_opened()))
+      shiny::isolate(isFALSE(ravedash::watch_loader_opened()))
     }
     reset <- function(...) {
       ravedash::logger("Updating {id}", level = "trace", use_glue = TRUE)
@@ -216,12 +192,12 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
       electrodes <- repo$electrode_list
       electrode_table <- repo$electrode_table
       electrode_table <- electrode_table[electrode_table$Electrode %in%
-                                           electrodes, ]
+          electrodes, ]
       electrode_table_names <- names(electrode_table)
       electrode_text <- dipsaus::parse_svec(get_default(sub_id = NULL,
-                                                        missing = NULL))
+        missing = NULL))
       electrode_text <- electrode_text[electrode_text %in%
-                                         repo$electrode_list]
+          repo$electrode_list]
       if (!length(electrode_text)) {
         electrode_text <- electrodes[[1]]
       }
@@ -230,133 +206,133 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
       }
       electrode_text <- dipsaus::deparse_svec(electrode_text)
       electrode_category_selector <- get_default(sub_id = category_str,
-                                                 missing = c("freesurferlabel", "FSLabel", comp$get_sub_element_input(category_str)),
-                                                 constraint = electrode_table_names)
+        missing = c("freesurferlabel", "FSLabel", comp$get_sub_element_input(category_str)),
+        constraint = electrode_table_names)
       ravedash::logger("Updating `{id}__{category_str}`, value: {electrode_category_selector} {length(electrode_table_names)}",
-             level = "trace", use_glue = TRUE)
+        level = "trace", use_glue = TRUE)
       shiny::updateSelectInput(session = session, inputId = comp$get_sub_element_id(category_str,
-                                                                                    with_namespace = FALSE), choices = electrode_table_names,
-                               selected = electrode_category_selector)
+        with_namespace = FALSE), choices = electrode_table_names,
+        selected = electrode_category_selector)
       electrode_list_text <- dipsaus::deparse_svec(repo$electrode_list,
-                                                   collapse = ", ")
+        collapse = ", ")
       ravedash::logger("Updating `{id}`, value: {electrode_text}, label: Select by number (current: {electrode_list_text})",
-             level = "trace", use_glue = TRUE)
+        level = "trace", use_glue = TRUE)
       if (multiple) {
         shiny::updateTextInput(session = session, inputId = comp$get_sub_element_id(with_namespace = FALSE),
-                               label = sprintf("Elec # (available: %s)",
-                                               electrode_list_text), value = electrode_text)
+          label = sprintf("Elec # (available: %s)",
+            electrode_list_text), value = electrode_text)
       }
       else {
         shiny::updateSelectInput(session = session, inputId = comp$get_sub_element_id(with_namespace = FALSE),
-                                 label = sprintf("Elec # (available: %s)",
-                                                 electrode_list_text), choices = as.character(repo$electrode_list),
-                                 selected = electrode_text)
+          label = sprintf("Elec # (available: %s)",
+            electrode_list_text), choices = as.character(repo$electrode_list),
+          selected = electrode_text)
       }
     }
     dipsaus::sync_shiny_inputs(input, session, c(comp$get_sub_element_id(with_namespace = FALSE),
-                                                 comp$get_sub_element_id(with_namespace = FALSE, sub_id = category_choices_str)),
-                               uniform = list(function(electrode_text) {
-                                 repository <- get_repo()
-                                 if (is.null(repository)) {
-                                   return(NULL)
-                                 }
-                                 electrodes <- dipsaus::parse_svec(electrode_text)
-                                 electrodes <- electrodes[electrodes %in% repository$electrode_list]
-                                 if (!length(electrodes)) {
-                                   electrodes <- NULL
-                                 }
-                                 electrodes
-                               }, function(category_selected) {
-                                 if (!length(category_selected)) {
-                                   return(NULL)
-                                 }
-                                 repository <- get_repo()
-                                 if (is.null(repository)) {
-                                   return(NULL)
-                                 }
-                                 category_name <- comp$get_sub_element_input(category_str)
-                                 current_electrodes <- dipsaus::parse_svec(comp$current_value)
-                                 current_electrodes <- current_electrodes[current_electrodes %in%
-                                                                            repository$electrode_list]
-                                 if (!length(current_electrodes)) {
-                                   current_electrodes <- NULL
-                                 }
-                                 if (length(category_name) && category_name %in%
-                                     names(repository$electrode_table) && length(repository$electrode_table[[category_name]])) {
-                                   choices <- repository$electrode_table[[category_name]]
-                                   all_electrodes <- repository$electrode_table$Electrode
-                                   expected_category <- choices[all_electrodes %in%
-                                                                  current_electrodes]
-                                   if (!setequal(expected_category, category_selected)) {
-                                     electrodes <- all_electrodes[choices %in%
-                                                                    category_selected & repository$electrode_table$isLoaded]
-                                     return(electrodes)
-                                   }
-                                 }
-                                 return(current_electrodes)
-                               }), updates = list(function(electrodes) {
-                                 if (length(electrodes)) {
-                                   if (multiple) {
-                                     new_value <- dipsaus::deparse_svec(electrodes)
-                                     if (!identical(new_value, comp$current_value)) {
-                                       val <- dipsaus::deparse_svec(electrodes)
-                                       ravedash::logger("Updating `{id}`, value: {val}",
-                                              level = "trace", use_glue = TRUE)
-                                       shiny::updateTextInput(session = session,
-                                                              inputId = id, value = val)
-                                     }
-                                   } else {
-                                     val <- as.character(electrodes[[1]])
-                                     ravedash::logger("Updating `{id}`, value: {val}", level = "trace",
-                                            use_glue = TRUE)
-                                     shiny::updateSelectInput(session = session,
-                                                              inputId = id, selected = val)
-                                   }
-                                 }
-                               }, function(electrodes) {
-                                 if (length(electrodes)) {
-                                   repository <- get_repo()
-                                   if (is.null(repository)) {
-                                     return(NULL)
-                                   }
-                                   input_str <- comp$get_sub_element_id(category_choices_str,
-                                                                        with_namespace = FALSE)
-                                   category_name <- comp$get_sub_element_input(category_str)
-                                   if (length(category_name) && category_name %in%
-                                       names(repository$electrode_table) && length(repository$electrode_table[[category_name]])) {
-                                     choices <- repository$electrode_table[[category_name]]
-                                     all_electrodes <- repository$electrode_table$Electrode
-                                     expected_category <- choices[all_electrodes %in%
-                                                                    electrodes]
-                                     category_selected <- comp$get_sub_element_input(category_choices_str)
-                                     if (!setequal(expected_category, category_selected)) {
-                                       if (!length(expected_category)) {
-                                         expected_category <- character(0L)
-                                       }
-                                       ravedash::logger("Updating `{id}__{category_choices_str}` ({length(expected_category)})",
-                                              level = "trace", use_glue = TRUE)
-                                       shiny::updateSelectInput(session = session,
-                                                                inputId = input_str, selected = expected_category)
-                                     }
-                                   }
-                                 }
-                               }))
+      comp$get_sub_element_id(with_namespace = FALSE, sub_id = category_choices_str)),
+      uniform = list(function(electrode_text) {
+        repository <- get_repo()
+        if (is.null(repository)) {
+          return(NULL)
+        }
+        electrodes <- dipsaus::parse_svec(electrode_text)
+        electrodes <- electrodes[electrodes %in% repository$electrode_list]
+        if (!length(electrodes)) {
+          electrodes <- NULL
+        }
+        electrodes
+      }, function(category_selected) {
+        if (!length(category_selected)) {
+          return(NULL)
+        }
+        repository <- get_repo()
+        if (is.null(repository)) {
+          return(NULL)
+        }
+        category_name <- comp$get_sub_element_input(category_str)
+        current_electrodes <- dipsaus::parse_svec(comp$current_value)
+        current_electrodes <- current_electrodes[current_electrodes %in%
+            repository$electrode_list]
+        if (!length(current_electrodes)) {
+          current_electrodes <- NULL
+        }
+        if (length(category_name) && category_name %in%
+            names(repository$electrode_table) && length(repository$electrode_table[[category_name]])) {
+          choices <- repository$electrode_table[[category_name]]
+          all_electrodes <- repository$electrode_table$Electrode
+          expected_category <- choices[all_electrodes %in%
+              current_electrodes]
+          if (!setequal(expected_category, category_selected)) {
+            electrodes <- all_electrodes[choices %in%
+                category_selected & repository$electrode_table$isLoaded]
+            return(electrodes)
+          }
+        }
+        return(current_electrodes)
+      }), updates = list(function(electrodes) {
+        if (length(electrodes)) {
+          if (multiple) {
+            new_value <- dipsaus::deparse_svec(electrodes)
+            if (!identical(new_value, comp$current_value)) {
+              val <- dipsaus::deparse_svec(electrodes)
+              ravedash::logger("Updating `{id}`, value: {val}",
+                level = "trace", use_glue = TRUE)
+              shiny::updateTextInput(session = session,
+                inputId = id, value = val)
+            }
+          } else {
+            val <- as.character(electrodes[[1]])
+            ravedash::logger("Updating `{id}`, value: {val}", level = "trace",
+              use_glue = TRUE)
+            shiny::updateSelectInput(session = session,
+              inputId = id, selected = val)
+          }
+        }
+      }, function(electrodes) {
+        if (length(electrodes)) {
+          repository <- get_repo()
+          if (is.null(repository)) {
+            return(NULL)
+          }
+          input_str <- comp$get_sub_element_id(category_choices_str,
+            with_namespace = FALSE)
+          category_name <- comp$get_sub_element_input(category_str)
+          if (length(category_name) && category_name %in%
+              names(repository$electrode_table) && length(repository$electrode_table[[category_name]])) {
+            choices <- repository$electrode_table[[category_name]]
+            all_electrodes <- repository$electrode_table$Electrode
+            expected_category <- choices[all_electrodes %in%
+                electrodes]
+            category_selected <- comp$get_sub_element_input(category_choices_str)
+            if (!setequal(expected_category, category_selected)) {
+              if (!length(expected_category)) {
+                expected_category <- character(0L)
+              }
+              ravedash::logger("Updating `{id}__{category_choices_str}` ({length(expected_category)})",
+                level = "trace", use_glue = TRUE)
+              shiny::updateSelectInput(session = session,
+                inputId = input_str, selected = expected_category)
+            }
+          }
+        }
+      }))
     initialize_with_new_data_reactive <- function() {
       shidashi::clear_notifications(class = "_presets_analysis_electrode_selector2_error_",
-                                    session = session)
+        session = session)
       repository <- get_repo()
       if (is.null(repository)) {
         shidashi::show_notification(title = "Initialization Error",
-                                    message = c("Unable to initialize preset input `",
-                                                id, "`. The container repository has not been set up yet. ",
-                                                "This is a module error. Please contact the module author to ",
-                                                "fix this issue."), type = "warning", close = TRUE,
-                                    autohide = FALSE, collapse = "", session = session,
-                                    class = "_presets_analysis_electrode_selector2_error_")
+          message = c("Unable to initialize preset input `",
+            id, "`. The container repository has not been set up yet. ",
+            "This is a module error. Please contact the module author to ",
+            "fix this issue."), type = "warning", close = TRUE,
+          autohide = FALSE, collapse = "", session = session,
+          class = "_presets_analysis_electrode_selector2_error_")
         return()
       }
       electrodes <- dipsaus::parse_svec(get_default(NULL,
-                                                    missing = ""))
+        missing = ""))
       electrodes <- electrodes[electrodes %in% repository$electrode_list]
       if (!length(electrodes)) {
         electrodes <- repository$electrode_list[[1]]
@@ -365,13 +341,13 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
       electrode_table_names <- names(repository$electrode_table)
       if (!length(category) || !isTRUE(category %in% electrode_table_names)) {
         category <- get_default(sub_id = category_str,
-                                missing = c("freesurferlabel", "FSLabel"),
-                                constraint = electrode_table_names)
+          missing = c("freesurferlabel", "FSLabel"),
+          constraint = electrode_table_names)
         ravedash::logger("Updating `{id}__{category_str}`, value: {category} ({length(electrode_table_names)})",
-               level = "trace", use_glue = TRUE)
+          level = "trace", use_glue = TRUE)
         shiny::updateSelectInput(session = session, inputId = comp$get_sub_element_id(category_str,
-                                                                                      with_namespace = FALSE), choices = electrode_table_names,
-                                 selected = category)
+          with_namespace = FALSE), choices = electrode_table_names,
+          selected = category)
       }
       choices <- character(0L)
       if (length(category) && isTRUE(category %in% electrode_table_names)) {
@@ -381,10 +357,10 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
         }
       }
       ravedash::logger("Updating choices of `{id}__{category_choices_str}` ({length(choices)})",
-             level = "trace", use_glue = TRUE)
+        level = "trace", use_glue = TRUE)
       shiny::updateSelectInput(session = session, inputId = comp$get_sub_element_id(sub_id = category_choices_str,
-                                                                                    with_namespace = FALSE), choices = unique(choices),
-                               selected = character(0L))
+        with_namespace = FALSE), choices = unique(choices),
+        selected = character(0L))
       if (length(electrodes) && !multiple) {
         electrodes <- electrodes[[1]]
       }
@@ -393,33 +369,33 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
         v <- sprintf("%s ", v)
       }
       electrode_list_text <- dipsaus::deparse_svec(repository$electrode_list,
-                                                   collapse = ", ")
+        collapse = ", ")
       ravedash::logger("Updating `{id}`, value: {v}, label: Select electrode by number (currently loaded: {electrode_list_text})",
-             level = "trace", use_glue = TRUE)
+        level = "trace", use_glue = TRUE)
       if (multiple) {
         shiny::updateTextInput(session = session, inputId = id,
-                               label = sprintf("Elec # (available: %s)",
-                                               electrode_list_text), value = v)
+          label = sprintf("Elec # (available: %s)",
+            electrode_list_text), value = v)
       }
       else {
         shiny::updateSelectInput(session = session, inputId = id,
-                                 label = sprintf("Elec # (available: %s)",
-                                                 electrode_list_text), choices = as.character(repository$electrode_list),
-                                 selected = as.character(v))
+          label = sprintf("Elec # (available: %s)",
+            electrode_list_text), choices = as.character(repository$electrode_list),
+          selected = as.character(v))
       }
     }
     shiny::bindEvent(observe({
       initialize_with_new_data_reactive()
     }), comp$get_sub_element_input(category_str), ignoreNULL = TRUE,
-    ignoreInit = TRUE)
+      ignoreInit = TRUE)
     shiny::bindEvent(observe({
       reset()
     }), comp$get_sub_element_input(reset_str), ignoreNULL = TRUE,
-    ignoreInit = TRUE)
+      ignoreInit = TRUE)
     output[[comp$get_sub_element_id(selected_electrode_text_str,
-                                    with_namespace = FALSE)]] <- shiny::renderText({
-                                      dipsaus::deparse_svec(dipsaus::parse_svec(comp$current_value))
-                                    })
+      with_namespace = FALSE)]] <- shiny::renderText({
+        dipsaus::deparse_svec(dipsaus::parse_svec(comp$current_value))
+      })
     shiny::bindEvent(observe({
       repository <- get_repo()
       if (is.null(repository)) {
@@ -430,9 +406,9 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
       }
       current_electrodes <- dipsaus::parse_svec(comp$current_value)
       if (length(current_electrodes) || any(current_electrodes %in%
-                                            repository$electrode_list)) {
+          repository$electrode_list)) {
         elec <- current_electrodes[current_electrodes %in%
-                                     repository$electrode_list]
+            repository$electrode_list]
         elec <- elec[[1]]
         idx <- which(repository$electrode_list == elec)
         if (idx == 1) {
@@ -447,9 +423,9 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
         elec <- repository$electrode_list[[1]]
       }
       shiny::updateSelectInput(session = session, inputId = id,
-                               selected = as.character(elec))
+        selected = as.character(elec))
     }), comp$get_sub_element_input(btn_previous_str), ignoreNULL = TRUE,
-    ignoreInit = TRUE)
+      ignoreInit = TRUE)
     shiny::bindEvent(observe({
       repository <- get_repo()
       if (is.null(repository)) {
@@ -460,9 +436,9 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
       }
       current_electrodes <- dipsaus::parse_svec(comp$current_value)
       if (length(current_electrodes) || any(current_electrodes %in%
-                                            repository$electrode_list)) {
+          repository$electrode_list)) {
         elec <- current_electrodes[current_electrodes %in%
-                                     repository$electrode_list]
+            repository$electrode_list]
         elec <- elec[[1]]
         idx <- which(repository$electrode_list == elec)
         if (idx == length(repository$electrode_list)) {
@@ -477,9 +453,9 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
         elec <- repository$electrode_list[[1]]
       }
       shiny::updateSelectInput(session = session, inputId = id,
-                               selected = as.character(elec))
+        selected = as.character(elec))
     }), comp$get_sub_element_input(btn_next_str), ignoreNULL = TRUE,
-    ignoreInit = TRUE)
+      ignoreInit = TRUE)
     comp$set_tool("reset", reset, server_needed = TRUE)
     comp$set_tool("initialize_with_new_data", function() {
       shiny::isolate(initialize_with_new_data_reactive())
@@ -488,6 +464,118 @@ build_electrode_selector <- function (id = "electrode_text", varname = "analysis
   }
   comp
 }
+
+
+build_epoch_loader <- function (id = "loader_epoch_name", varname = "epoch_choice",
+  label = "Epoch and Trial Duration", loader_project_id = "loader_project_name",
+  loader_subject_id = "loader_subject_code")
+{
+  comp <- ravedash:::RAVEShinyComponent$new(id = id, varname = varname)
+  comp$depends <- c(loader_project_id, loader_subject_id)
+  comp$no_save <- "default"
+  pre_varname <- comp$get_sub_element_varnames("trial_starts")
+  post_varname <- comp$get_sub_element_varnames("trial_ends")
+  comp$ui_func <- function(id, value, depends) {
+    pre <- comp$get_settings_value(key = pre_varname, default = -1)
+    post <- comp$get_settings_value(key = post_varname, default = 2)
+    ravedash::flex_group_box(title = label,
+      shidashi::flex_item(size = 2,
+        shiny::selectInput(inputId = id, label = "Epoch name",
+          choices = c(value, ""), selected = value, multiple = FALSE)
+      ),
+      shidashi::flex_break(style='margin:-10px; padding:0px'),
+      shidashi::flex_item(shiny::p("Pre must be negative if you need a pre-stimulus baseline window."), size=2),
+      shidashi::flex_break(),
+      shidashi::flex_item(shiny::numericInput(inputId = comp$get_sub_element_id("trial_starts",
+        with_namespace = TRUE), label = "Pre", min = -10, step = .1,
+        value = pre)),
+      shidashi::flex_item(shiny::numericInput(inputId = comp$get_sub_element_id("trial_ends",
+        with_namespace = TRUE), label = "Post", min = 0, step = 0.1,
+        value = post)),
+      shidashi::flex_break(),
+      shidashi::flex_item(shinyWidgets::prettyCheckbox(inputId = comp$get_sub_element_id("default",
+        with_namespace = TRUE), label = "Set as the default",
+        status = "success", shape = "square", animation = "smooth")
+      )
+    )
+  }
+  comp$server_func <- function(input, output, session) {
+    loader_project <- comp$get_dependent_component(loader_project_id)
+    loader_subject <- comp$get_dependent_component(loader_subject_id)
+    get_subject <- loader_subject$get_tool("get_subject")
+    get_time_window <- function() {
+      subject <- get_subject()
+      if (inherits(subject, "RAVESubject")) {
+        pre <- comp$get_settings_value(key = pre_varname,
+          default = {
+            subject$get_default(pre_varname, default_if_missing = -1)
+          })
+        post <- comp$get_settings_value(key = post_varname,
+          default = {
+            subject$get_default(post_varname, default_if_missing = 2)
+          })
+      }
+      else {
+        pre <- comp$get_settings_value(key = pre_varname,
+          default = -1)
+        post <- comp$get_settings_value(key = post_varname,
+          default = 2)
+      }
+      raveio::validate_time_window(as.vector(rbind(pre,
+        post)))
+    }
+    shiny::bindEvent(observe({
+      open_loader <- ravedash::watch_loader_opened(session = session)
+      if (!open_loader) {
+        return()
+      }
+      if (!loader_subject$sv$is_valid()) {
+        return()
+      }
+      subject <- get_subject()
+      epoch_choices <- subject$epoch_names
+      default_epochname <- subject$get_default(id)
+      if (length(default_epochname)) {
+        default_epochname <- default_epochname[[1]]
+        shinyWidgets::updatePrettyCheckbox(session, inputId = comp$get_sub_element_id("default",
+          FALSE), label = sprintf("Set as the default (current: %s)",
+            default_epochname))
+      }
+      else {
+        shinyWidgets::updatePrettyCheckbox(session, inputId = comp$get_sub_element_id("default",
+          FALSE), label = "Set as the default")
+      }
+      epoch_name <- comp$get_settings_value(default = default_epochname,
+        constraint = epoch_choices, use_cache = TRUE)
+      shiny::updateSelectInput(session = session, inputId = id,
+        choices = epoch_choices, selected = epoch_name)
+    }), loader_project$current_value, loader_subject$current_value,
+      ravedash::watch_loader_opened(session = session), ignoreNULL = TRUE)
+  }
+  comp
+}
+
+
+component_container <- ravedash:::RAVEShinyComponentContainer$new(
+  module_id = module_id, pipeline_name = pipeline$pipeline_name
+)
+
+
+# Define components
+loader_project <- ravedash::presets_loader_project()
+loader_subject <- ravedash::presets_loader_subject()
+loader_electrodes <- ravedash::presets_loader_electrodes()
+loader_reference <- ravedash::presets_loader_reference()
+loader_viewer <- get_loader_3dviewer()#ravedash::presets_loader_3dviewer(height = "100%")
+
+
+str(loader_viewer$get_settings_value)
+
+
+import_export_pipeline <- ravedash::presets_import_export_subject_pipeline()
+
+loader_epoch <- build_epoch_loader()#  ravedash::presets_loader_epoch()
+
 
 # comp_condition_groups <- ravedash::presets_condition_groups()
 electrode_selector <- build_electrode_selector()

--- a/modules/power_explorer/R/module_html.R
+++ b/modules/power_explorer/R/module_html.R
@@ -173,6 +173,26 @@ module_html <- function(){
                                  selected = pe_graphics_settings_cache$get('heatmap_color_palette') %OF% heatmap_palettes
               )
             ),
+            # ---- Input tab: Save for group analysis --------------------------------
+
+            ravedash::input_card(
+              class_header = "shidashi-anchor", title = "Save for Group Analysis",
+              shiny::p("Data from currently-selected electrodes will be saved on the RAVE server in the subject's directory.", shiny::br(),
+                       "Be sure to provide a unique label (timestamps are automatic). ",
+              "If you select Create New, but reuse an existing label, the original export will not be deleted, "
+              , "but it may become inaccessible from within RAVE."),
+              shiny::p("Using the same label across multiple subjects will greatly facilitate group analysis"),
+              shiny::selectInput(ns("replace_existing_group_anlysis_pipeline"), label = 'Create new / Replace existing pipeline',
+                                 choices = 'Create New'),
+              shiny::textInput(
+                inputId = ns("save_pipeline_for_group_analysis_label"),
+                label = "Label for results (spaces/special chars will be replaced)",
+                placeholder = "compare_A_and_B_pct_signal_change"
+              ),
+
+              dipsaus::actionButtonStyled(ns('save_pipeline_for_group_analysis'), 'Save!', icon = ravedash::shiny_icons$save)
+            ),
+
             # ---- Input tab: Export Electrodes --------------------------------
 
             ravedash::input_card(
@@ -248,6 +268,7 @@ module_html <- function(){
                 icon = ravedash::shiny_icons$export
               )
             ),
+
 
             # ---- Input tab: Export Power Point --------------------------------
 

--- a/modules/power_explorer/R/module_server.R
+++ b/modules/power_explorer/R/module_server.R
@@ -537,6 +537,7 @@ module_server <- function(input, output, session, ...){
 
   }), input$pes_select_mode, ignoreInit = TRUE, ignoreNULL = TRUE)
 
+
   shiny::bindEvent(ravedash::safe_observe({
     on.exit({shiny::removeModal()})
 
@@ -2557,6 +2558,7 @@ module_server <- function(input, output, session, ...){
 
   ravedash::register_output(
     outputId = "by_frequency_over_time",
+
     render_function = shiny::renderPlot({
       # req(FALSE)
 
@@ -2747,6 +2749,7 @@ module_server <- function(input, output, session, ...){
     outputId = "over_time_by_condition",
     render_function = shiny::renderPlot({
       basic_checks(local_reactives$update_outputs)
+
       force(local_reactives$update_line_plots)
       force(local_reactives$update_over_time_plot)
 

--- a/modules/power_explorer/R/shared-graphing.R
+++ b/modules/power_explorer/R/shared-graphing.R
@@ -1736,9 +1736,11 @@ plot_grouped_data <- function(mat, xvar, yvar='y', gvar=NULL, ...,
   ylim=NULL, col=NULL, do_axes=TRUE,
   names.pos = c('none', 'bottom', 'top'),
   plot_options = NULL, jitter_seed=NULL, cex_multifigure_scale=TRUE,
-  just_get_ylim = FALSE, repeated_index='Trial') {
+  just_get_ylim = FALSE, repeated_index='Trial', apply_theme=TRUE) {
 
-  apply_current_theme()
+  if(apply_theme) {
+    apply_current_theme()
+  }
 
   # here we need to know about grouping var, x-axis
   if(is.null(plot_options)) {

--- a/modules/power_explorer/R/shared-graphing.R
+++ b/modules/power_explorer/R/shared-graphing.R
@@ -1,170 +1,288 @@
 
+get_line_palette <- function(pname, get_palettes=FALSE, get_palette_names=FALSE) {
+  # from: http://colorbrewer2.org/ or in R or from unknown
 
-draw_many_heat_maps <- function (hmaps, meta_data,
-                                 max_zlim = 0, percentile_range = FALSE, log_scale = FALSE,
-                                 show_color_bar = TRUE, useRaster = TRUE, wide = FALSE, PANEL.FIRST = NULL,
-                                 PANEL.LAST = NULL, PANEL.COLOR_BAR = NULL, axes = c(TRUE,
-                                                                                     TRUE), plot_time_range = NULL, special_case_first_plot = FALSE,
-                                 max_columns = 2, decorate_all_plots = FALSE, center_multipanel_title = FALSE,
-                                 ignore_time_range = NULL, marginal_text_fields = c("Subject",
-                                                                                    "Electrodes"), extra_plot_parameters = NULL,
-                                 do_layout = TRUE, ...)
+  .palettes <- list(
+    'Beautiful Field' = c("orange", "dodgerblue3", "darkgreen", "orangered", "brown",  "purple3"),
+    'J5' = c("#407899","#deba6f", "#65743a", "#de6449", "#4B296B"),
+    'Okabe-Ito' = c("black", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2",
+      "#D55E00", "#CC79A7", "gray60"),
+    'Okabe-Ito 2' = c("#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2",
+      "#D55E00", "#CC79A7", "gray60"),
+    'Black+tan' = c('#1A1A19', '#A25D34', '#353634', '#D0A380'),
+    'Accent' = c('#7fc97f','#beaed4','#fdc086','#ffff99','#386cb0','#f0027f','#bf5b17','#656565'),
+    'Dark2' = c('#1b9e77','#d95f02','#7570b3','#e7298a','#66a61e','#e6ab02','#a6761d','#656565'),
+    'R4' = c("black", "#DF536B", "#61D04F", "#2297E6", "#28E2E5", "#CD0BBC", "#F5C710", "gray62"),
+    'R4Permed' = c("#2297E6", "#F5C710", "#61D04F", "#DF536B", "#CD0BBC"),
+    'Paired' = c('#a6cee3','#1f78b4','#b2df8a','#33a02c','#fb9a99','#e31a1c','#fdbf6f','#ff7f00'),
+    'Pastel1' = c('#fbb4ae','#b3cde3','#ccebc5','#decbe4','#fed9a6','#ffffcc','#e5d8bd','#fddaec'),
+    'Pastel2' = c('#b3e2cd','#fdcdac','#cbd5e8','#f4cae4','#e6f5c9','#fff2ae','#f1e2cc','#cccccc'),
+    'Set1' = c('#e41a1c','#377eb8','#4daf4a','#984ea3','#ff7f00','#ffff33','#a65628','#f781bf'),
+    'Set2' = c('#66c2a5','#fc8d62','#8da0cb','#e78ac3','#a6d854','#ffd92f','#e5c494','#b3b3b3'),
+    'Set3' = c('#8dd3c7','#ffffb3','#bebada','#fb8072','#80b1d3','#fdb462','#b3de69','#fccde5')
+  )
+
+  if(missing(pname)) {
+    if(get_palette_names)
+      return (names(.palettes))
+
+    return (.palettes)
+  }
+
+  pal <- .palettes[[pname]]
+  if(is.null(pal)) {
+    warning("Invalid palette requested: ", pname, ". Returning random palette")
+    pal <- .palettes[[sample(seq_along(.palettes), 1)]]
+  }
+
+  return (pal)
+}
+
+apply_current_theme <- function(...) {
+  theme <- ravedash::current_shiny_theme()
+
+  par('bg'=theme$background, 'fg'=theme$foreground, 'col'=theme$foreground,
+    'col.axis' = theme$foreground)
+
+  grDevices::palette(get_line_palette(
+    pe_graphics_settings_cache$get('line_color_palette'))
+  )
+}
+
+
+build_palettes_and_ranges_for_omnibus_data <- function(omnidata) {
+
+  nms <- names(omnidata)[grepl("^[m\\ |t\\ |p\\ |F\\ |p_fdr]", names(omnidata))]
+
+  # this happens for the movie player
+  if(length(nms) == 0) {
+    nms = names(omnidata)[!names(omnidata) %in% c('Electrode', 'Time')]
+  }
+
+  val_ranges = sapply(nms, function(d) {
+    if (startsWith(d, 'p ') | startsWith(d, 'p_fdr'))
+      return(c(-.2, .2))
+    c(-1, 1) * ceiling(max(abs(omnidata[[d]])))
+  }, simplify = FALSE, USE.NAMES = TRUE)
+
+  .colors = pe_graphics_settings_cache$get('heatmap_color_palette')
+  if(is.list(.colors)) .colors = .colors[[1]]
+
+  pal = ravebuiltins::expand_heatmap(.colors, ncolors=128)
+  pval_pal = ravebuiltins::expand_heatmap(
+    rev(tail(.colors, ceiling(length(.colors)/2))),
+    ncolors=128, bias=10)
+  pals = list(pal)
+
+  pals[seq_along(nms)] = pals
+  # names(pals) = fix_name_for_js(names(by_electrode_results))
+  names(pals) = nms
+
+  pals[startsWith(names(pals), 'p(')] = list(pval_pal)
+  pals[startsWith(names(pals), 'p_fdr')] = list(pval_pal)
+  pals[names(pals) %in% c('p')] = list(pval_pal)
+
+  return(
+    list(
+      palettes = pals,
+      val_ranges = val_ranges
+    )
+  )
+}
+
+draw_many_heat_maps <- function (hmaps,
+  max_zlim = 0, percentile_range = FALSE, log_scale = FALSE,
+  show_color_bar = TRUE, useRaster = TRUE, PANEL.FIRST = NULL,
+  PANEL.LAST = NULL, PANEL.COLOR_BAR = NULL,
+  axes = c(TRUE, TRUE), plot_time_range = NULL, special_case_first_plot = FALSE,
+  ncol = 3, byrow=TRUE, decorate_all_plots = FALSE, center_multipanel_title = FALSE,
+  ignore_time_range = NULL,
+  #marginal_text_fields = c("Subject", "Electrodes"),
+  extra_plot_parameters = NULL,
+  do_layout = TRUE, ...)
 {
 
-    #pe_graphics_settings_cache is defined in aa.R
-    rave_cex.axis <- pe_graphics_settings_cache$get('rave_cex.axis', missing_default = 1.3)
-    rave_cex.main <- pe_graphics_settings_cache$get('rave_cex.main', missing_default = 1.5)
+  #pe_graphics_settings_cache is defined above
+  rave_cex.axis <- pe_graphics_settings_cache$get('rave_cex.axis', missing_default = 1.3)
+  rave_cex.main <- pe_graphics_settings_cache$get('rave_cex.main', missing_default = 1.5)
+
+  # how many of the maps actually have usable data (use the range argument)
+  has_data <- which(!sapply(hmaps, function(x) {
+    if(!is.null(x$range)) {
+      return(any(is.nan(x$range)))
+    }
+    return(range(x$data))
+  }))
+  # ravedash::logger('has_data:', has_data, level='warning')
+
+  if (do_layout) {
+    # has_data <- TRUE
+    # ncol=3
+    # show_color_bar = TRUE
+    # byrow=TRUE
+    orig.pars <- layout_heat_maps(length(has_data), max_col = ncol,
+      layout_color_bar = show_color_bar, byrow = byrow)
+    # par('mar')
+    # layout.show(2)
+    ## if you want us to do layout, then I assume you want us to setup colors too
+    apply_current_theme()
+  }
+  #some people were passing in NULL for max_zlim
+  max_zlim %?<-% 0
+
+  # if (any(par("mfrow") > 1)) {
+  #   default_mar <- c(5.1, 4.1, 4.1, 2.1)
+  #   if (all(par("mar") == default_mar)) {
+  #     mar2 %?<-% 4.5
+  #     par(mar = 0.1 + c(4, mar2, 5, 2))
+  #   }
+  #   if (!decorate_all_plots && do_layout) {
+  #     par(oma = pmax(c(0,0,2,0), par('oma')))
+  #   }
+  # } else {
+  #   if (all(par("mar") == default_mar)) {
+  #     par(mar = 0.1 + c(par("mar")[1], mar2, 5, 2))
+  #   }
+  # }
+
+  actual_lim = rutabaga::get_data_range(hmaps)
+  needs_round = FALSE
+  if (max_zlim <= 0) {
+    max_zlim <- max(abs(actual_lim), na.rm = TRUE)
+    needs_round=TRUE
+  } else if (percentile_range) {
+    needs_round=TRUE
+
+    if (max_zlim >= 100) {
+      max_zlim = (max_zlim/100) * max(abs(actual_lim),
+        na.rm = TRUE)
+    } else {
+
+      # if we have a zlim < 1, multiply by 100
+      if(max_zlim < 1) {
+        max_zlim = abs(100*max_zlim)
+      }
+
+      if (!is.numeric(ignore_time_range)) {
+        max_zlim <- quantile(abs(unlist(lapply(hmaps, getElement,
+          "data"))), probs = max_zlim/100, na.rm = TRUE)
+      }
+      else {
+        ind <- !(hmaps[[1]]$x %within% ignore_time_range)
+        max_zlim <- quantile(abs(unlist(lapply(hmaps, function(h) h$data[ind,
+        ]))), probs = max_zlim/100, na.rm = TRUE)
+      }
+    }
+  }
+
+  # we're rounding IFF the user didn't pick a plot max
+  if(needs_round) {
+    # Rounding may bother people if they like to report the range of the data
+    # (but we have the range printed above)
+    if (max_zlim > 100) {
+      max_zlim %<>% round(-1)
+    }
+    else if (max_zlim > 10) {
+      max_zlim %<>% round_to_nearest(5)
+    } else if (max_zlim > 1) {
+      max_zlim %<>% round
+    } else {
+      max_zlim %<>% round(abs(floor(log10(max_zlim))))
+    }
+  }
+
+  log_scale <- if (isTRUE(log_scale)) {
+    "y"
+  } else {
+    ""
+  }
+  for (mi in seq_along(has_data)) {
+    # mi=1
+    map = hmaps[[has_data[mi]]]
+    plot_time_range %?<-% range(map$x)
+    if (!all(map$x %within% plot_time_range)) {
+      .attr = attributes(map$data)
+      ind <- map$x %within% plot_time_range
+      map$x <- map$x[ind]
+      map$data <- map$data[ind, , drop = FALSE]
+      .attr$dim = attr(map$data, "dim")
+      if(length(.attr$dimnames) && length(.attr$dimnames$Time)) {
+        .attr$dimnames$Time <- .attr$dimnames$Time[ ind ]
+      }
+      attributes(map$data) <- .attr
+    }
+    x <- seq_along(map$x)
+    y <- seq_along(map$y)
+    mto = NULL
+    if (!decorate_all_plots && length(has_data) > 1) {
+      mto = list(allow_sid = FALSE, allow_enum = FALSE, allow_freq = FALSE, allow_sample_size = FALSE)
+      my_r = floor((mi - 1)/par("mfrow")[2]) + 1
+      my_c = 1 + (mi - 1) %% par("mfrow")[2]
+      ncol_wo_cbar <- par("mfrow")[2]
+      if (show_color_bar) {
+        if (my_c == par("mfrow")[2]) {
+          my_c = 1
+          my_r = my_r + 1
+        }
+        ncol_wo_cbar = ncol_wo_cbar - 1
+      }
+      if (mi + ncol_wo_cbar <= length(has_data)) {
+        map$xlab <- " "
+      }
+      if (my_c != 1) {
+        map$ylab <- " "
+      }
+    }
+    dy <- 0
+    pc_args = list()
+    if (log_scale == "y") {
+      dy <- (y[2] - y[1])/2 + min(y)
+      pc_args[c("xlim", "ylim", "cex.lab", "log")] = list(x,
+        y + dy, rave_cex.axis * get_cex_for_multifigure(),
+        "y")
+    } else {
+      pad = c(-0.5, 0.5)
+      pc_args[c("xlim", "ylim")] = list(range(x) +
+          pad, range(y) + pad)
+    }
+    if (!is.null(extra_plot_parameters)) {
+      pc_args[names(extra_plot_parameters)] = extra_plot_parameters
+    }
+
+    do.call(rutabaga::plot_clean, pc_args)
+    if (is.function(PANEL.FIRST)) {
+      PANEL.FIRST(map)
+    }
+    make_image(map$data, x = x, y = y, log = ifelse(log_scale,
+      "y", ""), zlim = c(-1, 1) * max_zlim)
 
 
-    # how many of the maps actually have usable data (use the range argument)
-    has_data <- which(!sapply(hmaps, function(x) {
-        if(!is.null(x$range)) {
-            return(any(is.nan(x$range)))
-        }
-        return(range(x$data))
-    }))
+    ### draw the axis labels (no drawn axes/ticks on the spectrogram: lwd=0, tcl=0)
+    axes %<>% rep_len(2)
 
-    ravedash::logger('has_data:', has_data, level='warning')
+    ### how many x and y ticks do we need?
+    if (axes[1]) {
+      xticks <- ..get_nearest_i(pretty(map$x), map$x)
+      rave_axis(1, at = xticks, labels = map$x[xticks],
+        tcl = 0, lwd = 0, mgpx = c(0, 0.75, 0))
+    }
 
-    if (do_layout) {
-        orig.pars <- layout_heat_maps(length(has_data), max_col = max_columns,
-                                      layout_color_bar = show_color_bar)
-    }
-    #some people were passing in NULL for max_zlim
-    max_zlim %?<-% 0
+    if(axes[2]) {
+      if (length(map$y) <= 5) {
+        yticks <- seq_along(map$y)
+      }
+      else if (diff(range(diff(sort(map$y)))) > 2) {
+        tck = map$y[c(1, round(length(map$y) * (1/3)),
+          round((2/3) * length(map$y)), 1 * length(map$y))]
+        yticks <- ..get_nearest_i(tck, map$y)
+      }
+      else {
+        yticks <- ..get_nearest_i(pretty(map$y), map$y)
+      }
 
-    if (wide) {
-        max_char_count = max(sapply(hmaps, function(h) ifelse(any(is.nan(h$range)),
-                                                              max(nchar(h$conditions)), 1)))
-        par(mar = c(par("mar")[1], 5.1 + max(0, (max_char_count -
-                                                     5) * 0.95), 2, 2))
+      rave_axis(2, at = yticks, labels = map$y[yticks],
+        tcl = 0, lwd = 0, mgpy = c(0, -1/4, 0))
     }
-    else {
-        if (any(par("mfrow") > 1)) {
-            default_mar <- c(5.1, 4.1, 4.1, 2.1)
-            if (all(par("mar") == default_mar)) {
-                par(mar = 0.1 + c(4, 4.5, 2, 0))
-            }
-            if (!decorate_all_plots && do_layout) {
-                par(oma = c(0, 0, 2, 0))
-            }
-        }
-        else {
-            if (all(par("mar") == default_mar)) {
-                par(mar = c(par("mar")[1], par("mar")[2], 2,
-                            2))
-            }
-        }
-    }
-    actual_lim = get_data_range(hmaps)
-    if (max_zlim <= 0) {
-        max_zlim <- max(abs(actual_lim), na.rm = TRUE)
-    }
-    else if (percentile_range) {
-        if (max_zlim >= 100) {
-            max_zlim = (max_zlim/100) * max(abs(actual_lim),
-                                            na.rm = TRUE)
-        } else {
-            if (!is.numeric(ignore_time_range)) {
-                max_zlim <- quantile(unlist(lapply(hmaps, getElement,
-                                                   "data")), probs = max_zlim/100, na.rm = TRUE)
-            }
-            else {
-                ind <- !(hmaps[[1]]$x %within% ignore_time_range)
-                max_zlim <- quantile(unlist(lapply(hmaps, function(h) h$data[ind,
-                ])), probs = max_zlim/100, na.rm = TRUE)
-            }
-        }
-        if (max_zlim > 100) {
-            max_zlim %<>% round(-1)
-        }
-        else if (max_zlim > 10) {
-            max_zlim %<>% round_to_nearest(5)
-        }
-    }
-    log_scale <- if (isTRUE(log_scale)) {
-        "y"
-    }
-    else {
-        ""
-    }
-    for (mi in seq_along(has_data)) {
-        map = hmaps[[has_data[mi]]]
-        plot_time_range %?<-% range(map$x)
-        if (!all(map$x %within% plot_time_range)) {
-            .attr = attributes(map$data)
-            ind <- map$x %within% plot_time_range
-            map$x <- map$x[ind]
-            map$data <- map$data[ind, , drop = FALSE]
-            .attr$dim = attr(map$data, "dim")
-            attributes(map$data) <- .attr
-        }
-        x <- seq_along(map$x)
-        y <- seq_along(map$y)
-        mto = NULL
-        if (!decorate_all_plots && length(has_data) > 1) {
-            mto = list(allow_sid = FALSE, allow_enum = FALSE, allow_freq = FALSE, allow_sample_size = FALSE)
-            my_r = floor((mi - 1)/par("mfrow")[2]) + 1
-            my_c = 1 + (mi - 1) %% par("mfrow")[2]
-            ncol_wo_cbar <- par("mfrow")[2]
-            if (show_color_bar) {
-                if (my_c == par("mfrow")[2]) {
-                    my_c = 1
-                    my_r = my_r + 1
-                }
-                ncol_wo_cbar = ncol_wo_cbar - 1
-            }
-            if (mi + ncol_wo_cbar <= length(has_data)) {
-                map$xlab <- " "
-            }
-            if (my_c != 1) {
-                map$ylab <- " "
-            }
-        }
-        dy <- 0
-        pc_args = list()
-        if (log_scale == "y") {
-            dy <- (y[2] - y[1])/2 + min(y)
-            pc_args[c("xlim", "ylim", "cex.lab", "log")] = list(x,
-                                                                y + dy, rave_cex.axis * get_cex_for_multifigure(),
-                                                                "y")
-        } else {
-            pad = c(-0.5, 0.5)
-            pc_args[c("xlim", "ylim")] = list(range(x) +
-                                                  pad, range(y) + pad)
-        }
-        if (!is.null(extra_plot_parameters)) {
-            pc_args[names(extra_plot_parameters)] = extra_plot_parameters
-        }
-        do.call(rutabaga::plot_clean, pc_args)
-        if (is.function(PANEL.FIRST)) {
-            PANEL.FIRST(map)
-        }
-        make_image(map$data, x = x, y = y, log = ifelse(log_scale,
-                                                        "y", ""), zlim = c(-1, 1) * max_zlim)
-
-        ### how many x and y ticks do we need?
-        xticks <- ..get_nearest_i(pretty(map$x), map$x)
-        if (length(map$y) <= 5) {
-            yticks <- seq_along(map$y)
-        }
-        else if (diff(range(diff(sort(map$y)))) > 2) {
-            tck = map$y[c(1, round(length(map$y) * (1/3)),
-                          round((2/3) * length(map$y)), 1 * length(map$y))]
-            yticks <- ..get_nearest_i(tck, map$y)
-        }
-        else {
-            yticks <- ..get_nearest_i(pretty(map$y), map$y)
-        }
-
-        ### draw the axis labels (no drawn axes/ticks on the spectrogram: lwd=0, tcl=0)
-        axes %<>% rep_len(2)
-        if (axes[1])
-            rave_axis(1, at = xticks, labels = map$x[xticks],
-                      tcl = 0, lwd = 0, mgpx = c(0, 0.5, 0))
-        if (axes[2])
-            rave_axis(2, at = yticks, labels = map$y[yticks],
-                      tcl = 0, lwd = 0, mgpy = c(0, 0.5, 0))
 
 
     # call the last decorator
@@ -178,18 +296,27 @@ draw_many_heat_maps <- function (hmaps, meta_data,
     }
   }
 
-    if (show_color_bar) {
-        .mar <- c(par("mar")[1], 3.5, 2, 1)
-        if (is.function(PANEL.COLOR_BAR)) {
-            .mar[3] = 4
-        }
-        .ylab = ""
-        .ylab <- hmaps[[has_data[1]]]$zlab
-        rave_color_bar(max_zlim, actual_lim, ylab = .ylab, mar = .mar)
-        if (is.function(PANEL.COLOR_BAR)) {
-            PANEL.COLOR_BAR(hmaps)
-        }
+  if (show_color_bar) {
+    yline = 2.5 + get_order_of_magnitude(max_zlim)
+    # max_zlim = 100
+    .mar <- c(par("mar")[1], max(3, yline+2), 5, 1)
+
+    if (is.function(PANEL.COLOR_BAR)) {
+      .mar[3] = 5
     }
+    .ylab = ""
+    .ylab <- hmaps[[has_data[1]]]$zlab
+    # par(mar=rep(2.5,4))
+    par('mar'=.mar)
+    print(paste("using mar: ", paste0(collapse=',', .mar)))
+
+    rave_color_bar(max_zlim, actual_lim, ylab = .ylab, mar = .mar,
+      ylab.line = yline
+    )
+    if (is.function(PANEL.COLOR_BAR)) {
+      PANEL.COLOR_BAR(hmaps)
+    }
+  }
 
   # if (!decorate_all_plots &&
   #     any(par("mfrow")[1] > 1, par("mfrow")[2] > 2)
@@ -222,30 +349,48 @@ draw_many_heat_maps <- function (hmaps, meta_data,
   invisible(hmaps)
 }
 
-layout_heat_maps <- function(k, max_col, ratio=4, layout_color_bar=TRUE, colorbar_cm=3.5) {
-    opars <- par(no.readonly = TRUE)
+layout_heat_maps <- function(k, max_col, ratio=3.5, byrow=TRUE,
+  layout_color_bar=TRUE, colorbar_cm=5) {
+  opars <- par(no.readonly = TRUE)
 
   # colorbar_cm <- 3.5
   if(plotting_to_file()) {
     colorbar_cm <- 3
   }
 
-    nr <- ceiling(k / max_col)
-    max_col = min(k, max_col)
-    m <- 1:k
-    mat <- matrix(c(m, rep.int(0, nr*max_col - k)), byrow = TRUE,
-                  nrow=nr, ncol = max_col)
-    widths <- rep(ratio, max_col)
-    if(layout_color_bar) {
-        mat <- cbind(mat, k+1)
-        widths <- c(widths, lcm(colorbar_cm))
+  nr <- ceiling(k / max_col)
+  max_col = min(k, max_col)
+  m <- 1:k
+  mat <- matrix(c(m, rep.int(0, nr*max_col - k)), byrow = byrow,
+    nrow=nr, ncol = max_col)
+  widths <- rep(ratio, max_col)
+
+  if(k==1) {
+    widths = 1
+  }
+
+
+  if(layout_color_bar) {
+    mat <- cbind(mat, k+1)
+    widths <- c(widths, lcm(colorbar_cm))
+  }
+
+
+
+  if(k > 1) {
+    newmar = par('mar')
+    if(newmar[4] == 2.1) {
+      newmar[4] = 0.1
+      par('mar' = newmar)
     }
-    layout(mat, widths=widths)
+  }
+
+  layout(mat, widths=widths)
 }
 
 plotting_to_file <- function() {
-    i = get0(".Devices", envir = baseenv(),
-             ifnotfound = list("-1"), inherits = FALSE)
+  i = get0(".Devices", envir = baseenv(),
+    ifnotfound = list("-1"), inherits = FALSE)
 
   if("-1" == i[[1]]) {
     return (FALSE)
@@ -299,9 +444,9 @@ make_image <- function(mat, x, y, zlim, col=NULL, log='', useRaster=TRUE, clip_t
 
   # with(make_image_mat, {
 
-    image(x=x, y=y, z=mat, zlim=zlim, col=col, useRaster=useRaster, log=log,
-          add=add, axes=F, xlab='', ylab='', main='')
-    # })
+  image(x=x, y=y, z=mat, zlim=zlim, col=col, useRaster=useRaster, log=log,
+    add=add, axes=F, xlab='', ylab='', main='')
+  # })
 
   # return the clipped zmat
   invisible(mat)
@@ -311,44 +456,52 @@ get_heatmap_palette <- function(pname, get_palettes=FALSE, get_palette_names=FAL
   # Some of these are from:
   # http://colorbrewer2.org
 
-    .heatmap_palettes <- list(
-        BlueWhiteRed = c("#67001f", "#b2182b", "#d6604d", "#f4a582", "#fddbc7", "#ffffff",
-                         "#d1e5f0", "#92c5de", "#4393c3", "#2166ac", "#053061") %>% rev,
-        BlueGrayRed = rev(c("#67001f", "#b2182b", "#d6604d", "#f4a582", "#b4b4b4", "#92c5de", "#4393c3", "#2166ac", "#053061")),
-        Spectral = c('#9e0142','#d53e4f','#f46d43','#fdae61','#fee08b','#ffffbf',
-                     '#e6f598','#abdda4','#66c2a5','#3288bd','#5e4fa2') %>% rev,
-        BrownWhiteGreen = c('#543005','#8c510a','#bf812d','#dfc27d','#f6e8c3','#f5f5f5',
-                            '#c7eae5','#80cdc1','#35978f','#01665e','#003c30'),
-        PinkWhiteGreen =c('#8e0152','#c51b7d','#de77ae','#f1b6da','#fde0ef','#f7f7f7',
-                          '#e6f5d0','#b8e186','#7fbc41','#4d9221','#276419'),
-        PurpleWhiteGreen = c('#40004b','#762a83','#9970ab','#c2a5cf','#e7d4e8','#f7f7f7',
-                             '#d9f0d3','#a6dba0','#5aae61','#1b7837','#00441b'),
-        OrangeWhitePurple = c('#7f3b08','#b35806','#e08214','#fdb863','#fee0b6','#f7f7f7',
-                              '#d8daeb','#b2abd2','#8073ac','#542788','#2d004b'),
-        BlackWhiteRed = c('#67001f','#b2182b','#d6604d','#f4a582','#fddbc7','#ffffff',
-                          '#e0e0e0','#bababa','#878787','#4d4d4d','#1a1a1a') %>% rev,
-        BlueYellowRed = c('#a50026','#d73027','#f46d43','#fdae61','#fee090','#ffffbf',
-                          '#e0f3f8','#abd9e9','#74add1','#4575b4','#313695') %>% rev,
-        GreenYellowRed = c('#a50026','#d73027','#f46d43','#fdae61','#fee08b','#ffffbf',
-                           '#d9ef8b','#a6d96a','#66bd63','#1a9850','#006837') %>% rev
-    )
-    if(missing(pname)) {
-        if(get_palette_names)
-            return (names(.heatmap_palettes))
+  .heatmap_palettes <- list(
+    BlueWhiteRed = c("#67001f", "#b2182b", "#d6604d", "#f4a582", "#fddbc7", "#ffffff",
+      "#d1e5f0", "#92c5de", "#4393c3", "#2166ac", "#053061") %>% rev,
+    BlueGrayRed = rev(c("#67001f", "#b2182b", "#d6604d", "#f4a582", "#b4b4b4",
+      "#92c5de", "#4393c3", "#2166ac", "#053061")),
+    Spectral = c('#9e0142','#d53e4f','#f46d43','#fdae61','#fee08b','#ffffbf',
+      '#e6f598','#abdda4','#66c2a5','#3288bd','#5e4fa2') %>% rev,
+    BrownWhiteGreen = c('#543005','#8c510a','#bf812d','#dfc27d','#f6e8c3','#f5f5f5',
+      '#c7eae5','#80cdc1','#35978f','#01665e','#003c30'),
+    PinkWhiteGreen =c('#8e0152','#c51b7d','#de77ae','#f1b6da','#fde0ef','#f7f7f7',
+      '#e6f5d0','#b8e186','#7fbc41','#4d9221','#276419'),
+    PurpleWhiteGreen = c('#40004b','#762a83','#9970ab','#c2a5cf','#e7d4e8','#f7f7f7',
+      '#d9f0d3','#a6dba0','#5aae61','#1b7837','#00441b'),
+    OrangeWhitePurple = c('#7f3b08','#b35806','#e08214','#fdb863','#fee0b6','#f7f7f7',
+      '#d8daeb','#b2abd2','#8073ac','#542788','#2d004b'),
+    BlackWhiteRed = c('#67001f','#b2182b','#d6604d','#f4a582','#fddbc7','#ffffff',
+      '#e0e0e0','#bababa','#878787','#4d4d4d','#1a1a1a') %>% rev,
+    BlueYellowRed = c('#a50026','#d73027','#f46d43','#fdae61','#fee090','#ffffbf',
+      '#e0f3f8','#abd9e9','#74add1','#4575b4','#313695') %>% rev,
+    GreenYellowRed = c('#a50026','#d73027','#f46d43','#fdae61','#fee08b','#ffffbf',
+      '#d9ef8b','#a6d96a','#66bd63','#1a9850','#006837') %>% rev
+  )
+  if(missing(pname)) {
+    if(get_palette_names)
+      return (names(.heatmap_palettes))
 
     return (.heatmap_palettes)
   }
 
+  pal <- .heatmap_palettes[[pname]]
+  if(is.null(pal)) {
+    cat2("Invalid palette requested: ", pname, ". Returning random palette",
+      level="WARNING")
+    pname = sample(names(.heatmap_palettes), 1)
     pal <- .heatmap_palettes[[pname]]
-    if(is.null(pal)) {
-        cat2("Invalid palette requested: ", pname, ". Returning random palette",
-             level="WARNING")
-        pname = sample(names(.heatmap_palettes), 1)
-        pal <- .heatmap_palettes[[pname]]
-    }
-    attr(pal, 'name') = pname
+  }
+  attr(pal, 'name') = pname
 
   return (pal)
+}
+
+set_currently_active_line_palette <- function(pal_name) {
+  pal_name <- pal_name %OF% get_line_palette(get_palette_names = TRUE)
+  pe_graphics_settings_cache$set(key='line_color_palette',
+    signature = pal_name,
+    value = pal_name)
 }
 
 get_currently_active_heatmap <- function() {
@@ -372,24 +525,6 @@ set_currently_active_heatmap <- function( pal_name, n_colors = 101 ) {
   )
 
   pe_graphics_settings_cache$set(key='heatmap_color_palette',
-                                 signature = pal_name,
-                                 value = pal_name)
-  pe_graphics_settings_cache$set(
-    key = 'current_heatmap_palette',
-    value = pal,
-    signature = paste0(pal_name, n_colors)
-  )
-}
-
-set_currently_active_heatmap <- function( pal_name, n_colors = 101 ) {
-  pal_name <- pal_name %OF% get_heatmap_palette(get_palette_names = TRUE)
-
-  pal <- ravebuiltins::expand_heatmap(
-    ravebuiltins::get_heatmap_palette(pal_name),
-    ncolors = 101
-  )
-
-  pe_graphics_settings_cache$set(key='heatmap_color_palette',
     signature = pal_name,
     value = pal_name)
   pe_graphics_settings_cache$set(
@@ -401,16 +536,25 @@ set_currently_active_heatmap <- function( pal_name, n_colors = 101 ) {
 
 ..get_nearest_i <- function(from,to, condition=c('equal', 'less', 'greater')) {
 
-    if(lower_only) {
-        res <- sapply(from, function(.x) {
-            to2 = to[to<= .x]
-            which.min(abs(.x-to2))
-        })
-    } else {
-        res <- sapply(from, function(.x) {
-            which.min(abs(.x-to))
-        })
-    }
+  condition = match.arg(condition)
+
+  if(condition == 'less') {
+    res <- sapply(from, function(.x) {
+      ind <- (to<= .x)
+      to2 = to[ind]
+      which.min(abs(.x-to2))
+    })
+  } else if (condition == 'greater') {
+    res <- sapply(from, function(.x) {
+      ind = to>= .x
+      to2 = to[ind]
+      which.min(abs(.x-to2)) + (which(ind)[1] - 1)
+    })
+  } else {
+    res <- sapply(from, function(.x) {
+      which.min(abs(.x-to))
+    })
+  }
 
   return(res)
 }
@@ -439,7 +583,7 @@ map_indices_within <- function(from, to) {
 }
 
 rave_axis <- function(side, at, tcl, labels=at, las=1, cex.axis,
-                      cex.lab, mgpy=c(3, .6, 0), mgpx=c(3, .75, 0), col, col.axis, ...) {
+  cex.lab, mgpy=c(3, .6, 0), mgpx=c(3, .75, 0), col, col.ticks, col.axis, ...) {
 
   # if the color isn't specified, then we are free to set the color to what we want.
   # set it to the fg color, same for lines and for ticks
@@ -459,8 +603,9 @@ rave_axis <- function(side, at, tcl, labels=at, las=1, cex.axis,
     mgpy = c(3,.5,0)
     mgpx = c(3,.4,0)
 
-        print("detected plotting to file")
-    }
+    # this messes up Rmarkdown
+    # dipsaus::cat2("detected plotting to file")
+  }
 
   rutabaga::ruta_axis(
     side = side,
@@ -494,8 +639,9 @@ rave_title <- function(main, cex.main, col, font=1, adj=0.5, ...) {
   title(main=list(main, cex=cex.main*get_cex_for_multifigure(), col=col, font=font), adj=adj)
 }
 
-rave_axis_labels <- function(xlab=NULL, ylab=NULL, col=NULL, cex.lab, line=NA, ...) {
-    col %?<-% get_foreground_color()
+rave_axis_labels <- function(xlab=NULL, ylab=NULL, col=NULL, cex.lab,
+  xline=1.5, yline=2.75, push_X=0, push_Y=0, hint=0, ...) {
+  col %?<-% par('col')
 
   cex.lab %?<-% pe_graphics_settings_cache$get('rave_cex.lab')
 
@@ -505,17 +651,17 @@ rave_axis_labels <- function(xlab=NULL, ylab=NULL, col=NULL, cex.lab, line=NA, .
     if (cex.lab > 1) cex.lab = 1
   }
 
-        if(!is.null(ylab)) {
-            title(xlab=NULL, ylab=ylab,
-                  cex.lab=cex.lab*get_cex_for_multifigure(),
-                  col.lab=col, line=2.75, ...)
-        }
+  if(!is.null(ylab)) {
+    title(xlab=NULL, ylab=ylab,
+      cex.lab=cex.lab*get_cex_for_multifigure(),
+      col.lab=col, line=yline+push_Y, ...)
+  }
 
-        if(!is.null(xlab)) {
-            title(xlab=xlab, ylab=NULL,
-                  cex.lab=cex.lab*get_cex_for_multifigure(),
-                  col.lab=col, line=1.5, ...)
-        }
+  if(!is.null(xlab)) {
+    title(xlab=xlab, ylab=NULL,
+      cex.lab=cex.lab*get_cex_for_multifigure(),
+      col.lab=col, line=xline+push_X, ...)
+  }
 
 }
 
@@ -546,11 +692,11 @@ setup_palette <- function() {
   pe_graphics_settings_cache$get('color_palette')
 }
 
-rave_color_bar <- function(zlim, actual_lim, clrs, ylab, ylab.line=1.5,
-                           mar=c(5.1, 5.1, 2, 2), adjust_for_nrow=TRUE, horizontal=FALSE, ...) {
-    # print('drawing color bar')
-    clrs %?<-% get_currently_active_heatmap()
-    cbar <- matrix(seq(-zlim, zlim, length=length(clrs))) %>% t
+rave_color_bar <- function(zlim, actual_lim, clrs, ylab, ylab.line=2,
+  mar=c(5.1, 5.1, 2, 2), adjust_for_nrow=TRUE, horizontal=FALSE, ...) {
+  # print('drawing color bar')
+  clrs %?<-% get_currently_active_heatmap()
+  cbar <- matrix(seq(-zlim, zlim, length=length(clrs))) %>% t
 
   if(horizontal) cbar %<>% t
 
@@ -563,10 +709,10 @@ rave_color_bar <- function(zlim, actual_lim, clrs, ylab, ylab.line=1.5,
   orig.pty <- par('pty')
   on.exit(par(pty=orig.pty))
 
-    par(mar=mar, pty='m')
-    image(cbar, useRaster = FALSE, ylim=ylim,
-          col=clrs, axes=F, ylab='', main='',
-          col.lab = get_foreground_color())
+  # par(mar=mar, pty='m')
+  image(cbar, useRaster = FALSE, ylim=ylim,
+    col=clrs, axes=F, ylab='', main='',
+    col.lab = par('fg'))
 
   # check if any other graphics params were requested, direct them to the proper function
   more = list(...)
@@ -580,8 +726,13 @@ rave_color_bar <- function(zlim, actual_lim, clrs, ylab, ylab.line=1.5,
     do.call(rave_axis_labels, ral.args)
   }
 
-    ra.args = list(side=2, at=0:1, labels=pretty_round(c(-zlim,zlim), allow_negative_round = TRUE), tcl=0)
-    if('cex.axis' %in% more) ra.args$cex.axis = more$cex.axis
+  ra.args = list(side=2, at=0:1,
+    labels=#pretty_round(
+      c(-zlim,zlim),
+    # allow_negative_round = TRUE),
+    tcl=0)
+
+  if('cex.axis' %in% more) ra.args$cex.axis = more$cex.axis
 
   if(horizontal) ra.args$side = 1
   do.call(rave_axis, ra.args)
@@ -589,15 +740,15 @@ rave_color_bar <- function(zlim, actual_lim, clrs, ylab, ylab.line=1.5,
   ra.args[c('at', 'labels', 'tcl')] = list(0.5, 0, 0.3)
   do.call(rave_axis, ra.args)
 
-    # this won't work if we're tweaking ylim based on nrow
-    # the source for box is compiled, but this seems to work. The key is the xpd=T to make sure
-    # we don't get clipping
-    if(!horizontal) {
-        rect(par('usr')[1], 0, par('usr')[2], 1,
-             lwd=1, xpd=TRUE)
-    } else {
-        box()
-    }
+  # this won't work if we're tweaking ylim based on nrow
+  # the source for box is compiled, but this seems to work. The key is the xpd=T to make sure
+  # we don't get clipping
+  if(!horizontal) {
+    rect(par('usr')[1], 0, par('usr')[2], 1,
+      lwd=1, xpd=TRUE)
+  } else {
+    box()
+  }
 
   invisible(zlim)
 }
@@ -612,8 +763,8 @@ draw_box <- function(x,y, ...)  {
 }
 
 
-time_frequency_decorator <- function(data, condition_data, analysis_settings, baseline_settings, Xmap=force, Ymap=force,
-                                     analysis_window_type = c('box', 'line', 'shade'), ...) {
+time_frequency_decorator <- function(data, condition_data, baseline_settings, Xmap=force, Ymap=force,
+  analysis_window_type = c('box', 'line', 'shade'), ...) {
 
   analysis_window_type = match.arg(analysis_window_type)
 
@@ -624,14 +775,19 @@ time_frequency_decorator <- function(data, condition_data, analysis_settings, ba
     # label the x and y axes
     rave_axis_labels(data$xlab, data$ylab)
 
+    render_vertical <- function(wi, txt, col=adjustcolor(par('fg'), offset=rep(.3, 4)),
+      lty=2, adjust_text=c(0,0)) {
+      abline(v=Xmap(wi), lty=lty, col=col)
 
-        render_vertical <- function(wi, txt, col='gray30', lty=2) {
-            abline(v=Xmap(wi), lty=lty, col=col)
+      # cat(paste("RV: wi=", str_collapse(wi), " =>: ", str_collapse(Xmap(wi)), '\npar usr: ',
+      #             str_collapse(par('usr')), '\n'))
 
-            text(Xmap(wi[1]), par('usr')[4], txt, col=col, xpd=T, pos=4,
-                 cex = pe_graphics_settings_cache$get('rave_cex.lab') * get_cex_for_multifigure()
-            )
-        }
+      mtext(side=3, at=Xmap(wi[1])+adjust_text[1], adj=0,
+        # 1.0*par('usr')[4]+adjust_text[1],
+        text = txt, col=col,
+        cex = pe_graphics_settings_cache$get('rave_cex.lab')
+      )
+    }
 
     # label the baseline windows
     sapply(baseline_settings$window, render_vertical, 'Baseline')
@@ -639,15 +795,20 @@ time_frequency_decorator <- function(data, condition_data, analysis_settings, ba
     # label the analysis window(s)
     render_window <- function(as, adjust_text=c(0,0), ...) {
 
-            if(analysis_window_type == 'line') {
-                render_vertical(as$time, as$label, col='black')
-            } else {
-                draw_box(x,y,lty=2,lwd=2, col='black')
-                text(x[1], y[1] + diff(y)*0.90, as$label, col='black', xpd=T, pos=4,
-                     cex = pe_graphics_settings_cache$get('rave_cex.lab') * get_cex_for_multifigure()
-                )
-            }
-        }
+      if(analysis_window_type == 'line') {
+        render_vertical(wi = as$time, txt = as$label, col=par('fg'), adjust_text = adjust_text, ...)
+      } else {
+        x <- Xmap(as$time); y <- Ymap(as$frequency)
+
+        draw_box(x,y,lty=2,lwd=2, col=par('fg'), ...)
+        mtext(side=3, at = x[1]+adjust_text[1], adj=0,
+          # y[1] + (diff(y)*1) + adjust_text[2],
+          text = as$label,
+          col=par('fg'), #xpd=T, pos=4,
+          cex = pe_graphics_settings_cache$get('rave_cex.lab')
+        )
+      }
+    }
 
     if('time' %in% names(data$settings)) {
       # this means there is only one set of settings
@@ -666,12 +827,12 @@ time_frequency_decorator <- function(data, condition_data, analysis_settings, ba
 }
 
 spectrogram_heatmap_decorator <- function(plot_data, plot_options, Xmap=force, Ymap=force, btype='line', atype='box',
-                                          title_options=list(allow_freq=FALSE), ...) {
-    to <- force(title_options)
-    plot_options = list(
-        plot_title_options = pe_graphics_settings_cache$get('plot_title_options'),
-        draw_decorator_labels = pe_graphics_settings_cache$get('draw_decorator_labels')
-    )
+  title_options=list(allow_freq=FALSE), ...) {
+  to <- force(title_options)
+  plot_options = list(
+    plot_title_options = pe_graphics_settings_cache$get('plot_title_options'),
+    draw_decorator_labels = pe_graphics_settings_cache$get('draw_decorator_labels')
+  )
 
   # the idea of more title options is that the caller might "know better" than the creator about
   # 'which' plot is being decorated and can selective (dis/en)able certain text
@@ -707,41 +868,41 @@ spectrogram_heatmap_decorator <- function(plot_data, plot_options, Xmap=force, Y
       btype = 'n'
     }
 
-        windows <- list(
-            'Baseline'=list(
-                window = if(btype == 'label') {
-                    plot_data$baseline_window
-                }else {
-                    Xmap(plot_data$baseline_window)
-                },
-                type=btype
-            ),
-            'Analysis'=list(
-                window = if(atype=='box') {
-                    list(x=Xmap(plot_data$analysis_window),
-                         y=Ymap(plot_data$frequency_window))
-                } else if(atype == 'label') {
-                    plot_data$analysis_window
-                }else {
-                    Xmap(plot_data$analysis_window)
-                },
-                type=atype
-            )
-        )
+    windows <- list(
+      'Baseline'=list(
+        window = if(btype == 'label') {
+          plot_data$baseline_window
+        }else {
+          Xmap(plot_data$baseline_window)
+        },
+        type=btype
+      ),
+      'Analysis'=list(
+        window = if(atype=='box') {
+          list(x=Xmap(plot_data$analysis_window),
+            y=Ymap(plot_data$frequency_window))
+        } else if(atype == 'label') {
+          plot_data$analysis_window
+        }else {
+          Xmap(plot_data$analysis_window)
+        },
+        type=atype
+      )
+    )
 
     if(isTRUE(plot_data$enable_frequency2)) {
 
-            windows[['F2 Analysis']] = list(
-                window = if(atype=='box') {
-                    list(x=Xmap(plot_data$analysis_window2),
-                         y=Ymap(plot_data$frequency_window2))
-                } else if(atype == 'label') {
-                    plot_data$analysis_window2
-                }else {
-                    Xmap(plot_data$analysis_window2)
-                },
-                type=atype
-            )
+      windows[['F2 Analysis']] = list(
+        window = if(atype=='box') {
+          list(x=Xmap(plot_data$analysis_window2),
+            y=Ymap(plot_data$frequency_window2))
+        } else if(atype == 'label') {
+          plot_data$analysis_window2
+        }else {
+          Xmap(plot_data$analysis_window2)
+        },
+        type=atype
+      )
 
       if('Analysis Window' %in% plot_options$plot_title_options) {
         plot_options$plot_title_options %<>% c('F2 Analysis Window')
@@ -761,16 +922,16 @@ spectrogram_heatmap_decorator <- function(plot_data, plot_options, Xmap=force, Y
           lpo = 0.75
         }
 
-                with(windows[[nm]],
-                     window_decorator(
-                         window=window, type=type,
-                         text=ifelse(plot_options$draw_decorator_labels, nm, ''))
-                )
-            }
-        })
-        # if(results$get_value('draw_decorator_labels')) {
-        #     rave_axis(1, at=Xmap(0), labels = plot_data$trial_alignment, mgpx=c(1,2,1), lwd=0, tcl=0)
-        # }
+        with(windows[[nm]],
+          window_decorator(
+            window=window, type=type,
+            text=ifelse(plot_options$draw_decorator_labels, nm, ''))
+        )
+      }
+    })
+    # if(results$get_value('draw_decorator_labels')) {
+    #     rave_axis(1, at=Xmap(0), labels = plot_data$trial_alignment, mgpx=c(1,2,1), lwd=0, tcl=0)
+    # }
 
     invisible(plot_data)
   }
@@ -788,9 +949,9 @@ axis_label_decorator <- function(plot_data, col, Xmap=force, Ymap=force, label_a
 }
 
 title_decorator <- function(plot_data, plot_title_options,
-                            allow_sid=TRUE, allow_enum=TRUE, allow_freq=TRUE,
-                            allow_cond=TRUE, allow_sample_size=TRUE, ..., plot=TRUE) {
-    title_string = ''
+  allow_sid=TRUE, allow_enum=TRUE, allow_freq=TRUE,
+  allow_cond=TRUE, allow_sample_size=TRUE, ..., plot=TRUE) {
+  title_string = ''
 
   # if(missing(plot_title_options)) {
   #     plot_title_options = build_plot_options()$plot_title_options
@@ -862,3 +1023,1983 @@ do_on_inclusion <- function(needle, expr, haystack) {
 round_to_nearest <- function(x, val=10) {
   val*round(x/val)
 }
+
+
+fill_poly <- function(x, y, fill.color=1, fill.alpha=0.6, y0=0, do_stroke=TRUE, stroke.lwd=2, stroke.color=fill.color) {
+  polygon( c(x, rev(x)), c(rep(y0, length(y)), rev(y)), border=NA, col=adjustcolor(fill.color, fill.alpha))
+  #overdraw the data line (this may do weird things if col already has transparency in it)
+  if(isTRUE(do_stroke)) lines(x, y, col=stroke.color, lwd=stroke.lwd)
+}
+
+is.color <- function(x) {
+  if(is.null(x) || is.function(x) || is.nan(x)) return (FALSE)
+
+  res <- tryCatch({
+    col2rgb(x)
+  }, error = function(...) {
+    FALSE
+  })
+  if(isFALSE(res)) return(FALSE)
+
+
+  return(TRUE)
+}
+
+render_analysis_window <- function(settings, lty=2, do_label=TRUE, text.color=par('fg'),
+  x, y, line.color=par('fg'), shade.color, stroke.color, shade.alpha=0.6) {
+  # settings <- dd$settings
+  wi = settings$time
+
+  # handle possibly-overlapping multiple time window labels
+  if(do_label) {
+    if(is.list(wi)) {
+
+    } else {
+      mtext(side=3, at=wi[1], adj=0,
+        text = settings$label, col=text.color,
+        cex = pe_graphics_settings_cache$get('rave_cex.lab')
+      )
+    }
+  }
+
+  if(is.numeric(lty)) abline(v=wi, lty=2, col=line.color)
+
+  if(!missing(y) && !missing(x)) {
+    ind <- x %within% settings$time
+    fill_poly(x=x[ind], y=y[ind], fill.color = shade.color, fill.alpha=shade.alpha, stroke.color=stroke.color)
+  }
+}
+
+plot_over_time_by_condition <- function(over_time_by_condition_data,
+  combine_conditions=FALSE,
+  combine_events=FALSE,
+  condition_switch=NULL,
+  plot_range=c(-Inf,Inf), ylim) {
+
+  if(is.character(condition_switch)){
+    if (condition_switch=='Separate all')  {
+      combine_events=FALSE
+      combine_conditions=FALSE
+    } else if (condition_switch == 'Combine conditions') {
+      combine_events = FALSE
+      combine_conditions=TRUE
+    } else if (condition_switch == 'Combine events')  {
+      combine_events = TRUE
+      combine_conditions=FALSE
+    } else if (condition_switch == 'Combine all') {
+      combine_events = TRUE
+      combine_conditions=TRUE
+    }
+  }
+
+  apply_current_theme()
+
+  n.groups <- length(over_time_by_condition_data)
+  n.events <- length(over_time_by_condition_data[[1]])
+
+  xlim <- range(
+    unlist(sapply(over_time_by_condition_data, function(otd) {
+      sapply(otd, function(dd) {c(min(dd$x), max(dd$x))})
+    }))
+  )
+
+  # intersect with the requested plot lim
+  new_lim <- c(
+    max(xlim[1], min(plot_range)),
+    min(xlim[2], max(plot_range))
+  )
+
+  if(any(new_lim != xlim)) {
+    xlim = new_lim
+
+    # trim the data before plotting
+    for(ii in seq_along(over_time_by_condition_data)) {
+      for(jj in seq_along(over_time_by_condition_data[[ii]])) {
+        ind <- over_time_by_condition_data[[ii]][[jj]]$x %within% xlim
+
+        over_time_by_condition_data[[ii]][[jj]]$x <-
+          over_time_by_condition_data[[ii]][[jj]]$x[ind]
+
+        over_time_by_condition_data[[ii]][[jj]]$data <-
+          over_time_by_condition_data[[ii]][[jj]]$data[ind,,drop=FALSE]
+      }
+    }
+  }
+
+  if(missing(ylim)) {
+    ylim <- sapply(over_time_by_condition_data, function(otd) {
+      range(sapply(otd, function(dd) {
+        rutabaga::plus_minus(dd$data)
+      }))
+    }) %>% pretty %>% range
+  }
+
+  draw_axis_labels <- function() {
+    nr = par('mfrow')[1]
+    nc = par('mfrow')[2]
+
+    x.dividers = seq_len(nc) * 1/nc
+    x.midpoints = x.dividers - 0.5*(1/nc)
+
+    y.dividers = seq_len(nr) * 1/nr
+    y.midpoints = y.dividers - 0.5*(1/nr)
+
+    rave_cex.axis <- pe_graphics_settings_cache$get('rave_cex.axis')
+    mtext(outer = TRUE, side=1, 'Time (s)', cex=rave_cex.axis, at=x.midpoints)
+    mtext(outer = TRUE, side=2, over_time_by_condition_data[[1]][[1]]$ylab, at=y.midpoints,
+      cex=rave_cex.axis, line=1)
+  }
+
+  decorate_plot <- function(graph_data, graph_num,
+    window_label= FALSE, window_type = c('lines', 'fill'), axes=TRUE) {
+    # draw the analysis window behind the data
+    sh = pe_graphics_settings_cache$get('analysis_window.shade.color')
+    if (sh == 'match') sh = graph_num
+
+    st = pe_graphics_settings_cache$get('analysis_window.stroke.color')
+    if (st == 'match') st = graph_num
+
+    if('fill' %in% window_type) {
+      render_analysis_window(graph_data$settings, do_label=window_label,
+        x=graph_data$x, y=graph_data$data[,1],
+        shade.color = sh,
+        stroke.color = st)
+    } else {
+      render_analysis_window(graph_data$settings, do_label=window_label,
+        shade.color = sh,
+        stroke.color = st)
+    }
+
+    axes = rep_len(axes, 2)
+    if(axes[1]) rave_axis(1, at=axTicks(1))
+    if(axes[2]) rave_axis(2, at=axTicks(2))
+
+    if(par('usr')[3] < 0) abline(h=0, col='lightgray')
+  }
+
+  # many situations merge into a 1,1 plot type, so have an function for that
+  plot_all_in_one <- function() {
+    par(mfrow=c(1,1), oma=c(2, 2.25, 0, 0), mar=c(2,2,2,1))
+    rutabaga::plot_clean(xlim, ylim)
+    draw_axis_labels()
+    dy = .075*diff(par('usr')[3:4])
+
+    for(ii in seq_along(over_time_by_condition_data)) {
+      for (jj in seq_along(over_time_by_condition_data[[ii]])) {
+        dd <- over_time_by_condition_data[[ii]][[jj]]
+        graph_num = jj + (n.events) * (ii-1)
+
+        # put the decorations behind the data
+        decorate_plot(graph_data = dd, graph_num = graph_num,
+          window_type = 'lines', axes=(graph_num==1),
+          # label windows every time there is a new event
+          window_label = (ii==1)
+        )
+
+        rutabaga::ebar_polygon(dd$x, dd$data[,1], dd$data[,2], col=graph_num)
+
+        yy = max(axTicks(2)) - dy*graph_num
+
+        text(x=axTicks(1)[1], y=yy,
+          labels =paste(dd$time_window_label, dd$data_label, sep=', '), adj=c(0,0),
+          cex = pe_graphics_settings_cache$get('rave_cex.lab', 1),
+          col=graph_num
+        )
+      }
+    }
+  }
+
+  plot_combined_over_conditions <- function(nr,nc) {
+    # we have at least 2 events
+    par(mfrow=c(nr,nc), oma=c(2, 2.25, 0, 0), mar=c(2,2,2,1))
+
+    #loop over events
+    for(ei in seq_along(over_time_by_condition_data[[1]])) {
+      rutabaga::plot_clean(xlim, ylim)
+      draw_axis_labels()
+      with(over_time_by_condition_data[[1]][[ei]],
+        rave_title(time_window_label)
+      )
+
+      if(ei==1) {
+        nms <- names(over_time_by_condition_data)
+        dy = .075*diff(par('usr')[3:4])
+        yy = max(axTicks(2)) - dy*seq_along(nms)
+
+        text(x=axTicks(1)[1], y=yy,
+          labels =nms, adj=c(0,0),
+          cex = pe_graphics_settings_cache$get('rave_cex.lab', 1),
+          col=seq_along(nms)
+        )
+      }
+
+      for(ii in seq_along(over_time_by_condition_data)) {
+        dd <- over_time_by_condition_data[[ii]][[ei]]
+        graph_num = ii
+
+        # put the decorations behind the data
+        decorate_plot(graph_data = dd, graph_num = graph_num,
+          window_type = 'lines', axes=(graph_num==1))
+
+        rutabaga::ebar_polygon(dd$x, dd$data[,1], dd$data[,2], col=graph_num)
+      }
+
+    }
+  }
+
+  plot_combined_over_events <- function(nr,nc) {
+    par(mfrow=c(nr,nc), oma=c(2, 2.25, 0, 0), mar=c(2,2,2,1))
+    for(ii in seq_along(over_time_by_condition_data)) {
+      rutabaga::plot_clean(xlim, ylim)
+      draw_axis_labels()
+      rave_title(over_time_by_condition_data[[ii]][[1]]$data_label)
+
+      if(ii==1) {
+        nms <- names(over_time_by_condition_data[[1]])
+        dy = .075*diff(par('usr')[3:4])
+        yy = max(axTicks(2)) - dy*seq_along(nms)
+
+        text(x=axTicks(1)[1], y=yy,
+          labels =nms, adj=c(0,0),
+          cex = pe_graphics_settings_cache$get('rave_cex.lab', 1),
+          col=seq_along(nms)
+        )
+      }
+
+      for(jj in seq_along(over_time_by_condition_data[[ii]])) {
+        dd <- over_time_by_condition_data[[ii]][[jj]]
+        graph_num = jj
+
+        # put the decorations behind the data
+        decorate_plot(graph_data = dd, graph_num = graph_num,
+          window_type = 'lines', axes=(graph_num==1))
+
+        rutabaga::ebar_polygon(dd$x, dd$data[,1], dd$data[,2], col=graph_num)
+      }
+    }
+    # show a warning if the events have a different origin
+  }
+
+  MAX_COL = pe_graphics_settings_cache$get('max_columns_in_figure', 3)
+
+  determine_layout <- function(n.panels) {
+    nr = ceiling(n.panels / MAX_COL)
+
+    nc = min(n.panels, MAX_COL)
+
+    c(nr,nc)
+  }
+
+  if(isTRUE(combine_conditions) && isTRUE(combine_events)){
+    # put everybody in a single plot
+    plot_all_in_one()
+  } else if (isTRUE(combine_conditions)){
+    # we're combining conditions (but not events), so the number of
+    # unique graphs is the number of unique events, second-level dimension
+    layout = determine_layout(length(over_time_by_condition_data[[1]]))
+
+    if(prod(layout)==1) {
+      plot_all_in_one()
+    } else {
+      plot_combined_over_conditions(nr=layout[1], nc=layout[2])
+    }
+
+  } else if (isTRUE(combine_events)){
+    # here we are combining events but not combining conditions
+    layout <- determine_layout(length(over_time_by_condition_data))
+
+    if(prod(layout) == 1) {
+      plot_all_in_one()
+    } else {
+      plot_combined_over_events(nr=layout[1], nc=layout[2])
+    }
+  } else {
+    # separate everything
+    k = n.groups * n.events
+
+    # determining our own layout to make sure it looks nice
+    nc = k %% n.groups
+    if(nc ==0) nc = n.groups
+    nr = ceiling(k / n.groups)
+
+    # prefer (1,X) to (X,1)
+    if(nr > 1 && nc ==1) {
+      nc = nr
+      nr = 1
+    }
+
+    par(mfcol=c(nr,nc), oma=c(2, 2.25, 0, 0), mar=c(2,2,2,1))
+    for(ii in seq_along(over_time_by_condition_data)) {
+      for(jj in seq_along(over_time_by_condition_data[[ii]])) {
+        rutabaga::plot_clean(xlim, ylim)
+        draw_axis_labels()
+        dd <- over_time_by_condition_data[[ii]][[jj]]
+        rave_title(paste(sep=' | ', dd$data_label, dd$time_window_label))
+
+        graph_num = jj + (ii-1)*n.events
+
+        # put the decorations behind the data
+        decorate_plot(graph_data = dd, graph_num = graph_num)
+
+        rutabaga::ebar_polygon(dd$x, dd$data[,1], dd$data[,2], col=graph_num)
+      }
+    }
+  }
+}
+
+plot_per_electrode_statistics <- function(stats, requested_stat, show0=c('smart', 'auto', 'always'),
+  which_plots=c('all', 'm', 't', 'p'), draw_threshold = NULL,
+  label_electrodes = NULL, label_type='number') {
+
+  if(missing(requested_stat) || is.null(requested_stat) || nchar(requested_stat) == 0) {
+    requested_stat = 'overall'
+  }
+  # make sure this matches which_plots above
+  plot.types = c('m', 't', 'p')
+
+  theme <- ravedash::current_shiny_theme()
+  par('bg'=theme$background, 'fg'=theme$foreground, 'col'=theme$foreground)
+
+
+  which_to_label = integer(0)
+  electrode_numbers <- as.integer(colnames(stats))
+  if(!is.null(label_electrodes)) {
+    which_to_label = which(electrode_numbers %in% label_electrodes)
+  }
+
+  label_type = match.arg(label_type,
+    choices = c('number', 'name', 'color', 'showcase', 'size'),
+    several.ok = TRUE)
+
+  electrode_names <- electrode_numbers
+
+  if('electrode_labels' %in% names(attributes(stats))) {
+    electrode_names <- attr(stats, 'electrode_labels')
+  }
+
+  # the first thing to check is if we are in 'showcase' mode
+  # if so, then chop off electrodes from the stats block
+  if(length(which_to_label) > 0 && 'showcase' %in% label_type) {
+    # this drops attributes which means we lose electrode labels
+    stats = stats[,which_to_label,drop=FALSE]
+    electrode_numbers <- as.integer(colnames(stats))
+    electrode_names <- electrode_names[which_to_label]
+    which_to_label <- seq_len(ncol(stats))
+  }
+
+  show0 = match.arg(show0)
+
+  which_plots = match.arg(which_plots)
+
+  tmp_ind = which(
+    stringr::str_detect(tolower(rownames(stats)),
+      tolower(requested_stat))
+  )
+
+  row_ind <- 1:3
+  if(length(tmp_ind)>1) {
+    row_ind = seq(from=tmp_ind[1], to=2+tmp_ind[1])
+  }
+
+  get_non_consec <- function(ee) {
+    res <- which(diff(ee)>1)
+    sort(c(res, res+1))
+  }
+
+  el_axis <- function() {
+    xat <- if(length(electrode_numbers) <= 5) {
+      seq_along(electrode_numbers)
+    } else {
+      unique(c(1, get_non_consec(electrode_numbers), length(electrode_numbers)))
+    }
+    rave_axis(1, at=xat, labels=electrode_numbers[xat], tcl=0)
+  }
+
+  do_draw_threshold <- function(th) {
+    abline(h=th, lty=2, col=pe_graphics_settings_cache$get('champions_tunic'))
+  }
+
+  ylabels <- list('p(' = 'p-value', 't(' = 't-score',
+    'm(' = 'mean', 'p_fdr(' = 'fdr p-value')
+
+  if('all' == which_plots) {
+    par(mfrow=c(1,3),mar=c(4.1,5.1,4.1,2.1))
+  } else {
+    row_ind = row_ind[which(which_plots == plot.types)]
+  }
+
+  for(ii in row_ind) {
+    cn <- rownames(stats)[ii]
+    ylab <- ylabels[[substr(cn, 1,2)]]
+    if(is.null(ylab)) {
+      ## check if we have a speciality p-value
+      if(startsWith(cn, 'p_fdr(')) {
+        ylab = ylabels[["p_fdr("]]
+      }
+    }
+
+    yy <- if(ylab %in% c('p-value', 'fdr p-value')) {
+      -log10(stats[ii, ])
+    } else {
+      stats[ii, ]
+    }
+
+    ylim = yy
+    if(show0 == 'always') {
+      ylim = c(0, yy)
+    } else if(show0 == 'smart') {
+      if(any(stringr::str_detect(cn, ' - '), stringr::str_detect(ylab, '(p-value|t-score)'))) {
+        ylim = c(0,yy)
+      }
+    }
+    rutabaga::plot_clean(seq_along(electrode_numbers), pretty(ylim))
+    el_axis()
+
+    if(stringr::str_detect(ylab, 'p-value')) {
+      for(ax in axTicks(2)) {
+        rave_axis(2, at=ax, labels=bquote(10**.(-ax)), tcl=0, cex.axis = 1)
+      }
+
+      rave_axis(2, at=axTicks(2), labels = FALSE)
+
+      ## draw threshold if needed
+      if(!is.null(draw_threshold)) {
+        do_draw_threshold(-log10(draw_threshold))
+      }
+
+    } else {
+      # because we're not drawing a box, it's awkward to have points below (above)
+      # the extreme ticks
+      planned_ticks = axTicks(2)
+      k = length(planned_ticks)
+      if(k %% 2 == 1) {
+        planned_ticks = planned_ticks[c(1, (k+1)/2, k)]
+      }
+      rave_axis(2, at=planned_ticks)
+
+      ## draw threshold if needed
+      if(!is.null(draw_threshold)) {
+        do_draw_threshold(draw_threshold)
+      }
+
+    }
+    rave_axis_labels(xlab='Electrode #', ylab=ylab, push_X = 0.75)
+    rave_title(cn)
+
+    # if(0 %within% range(ylim)) {
+    .x <- seq_along(electrode_numbers)
+    points(.x, yy, pch=19,
+      col=adjustcolor(par('col'), offset=rep(.35, 4)),
+      type='h', lwd=0.5)
+    # }
+    points(.x, yy, pch=19,
+      col= adjustcolor(par('col'), offset=rep(.25, 4))
+    )
+
+    if(length(which_to_label) > 0) {
+      if('number' %in% label_type) {
+        text(.x[which_to_label], yy[which_to_label], labels=electrode_numbers[which_to_label],
+          pos=ifelse(yy[which_to_label]<0, 1, 3), font=2, xpd=TRUE,
+          cex = pe_graphics_settings_cache$get('rave_cex.lab'),
+          xpd=TRUE)
+
+      }
+      if ('color' %in% label_type) {
+        # plotting at 1.01 to make sure we cover existing circle
+        points(.x[which_to_label], yy[which_to_label],
+          col=pe_graphics_settings_cache$get('champions_tunic'),
+          pch=19, cex=1.01)
+      }
+      if('name' %in% label_type) {
+
+        # if we are also plotting the numbers, then we want to move the names
+        # farther from the point
+        delta = if('number' %in% label_type) {
+          1.4 * strheight("1", font=2) * sign(yy[which_to_label])
+        } else {
+          0
+        }
+
+        text(.x[which_to_label], delta+yy[which_to_label],
+          labels=electrode_names[which_to_label],
+          pos=ifelse(yy[which_to_label]<0, 1, 3), font=2, xpd=TRUE,
+          cex = pe_graphics_settings_cache$get('rave_cex.lab'),
+          xpd=TRUE)
+      }
+    }
+  }
+}
+
+PE_COLLAPSE_METHODS <- c('mean', '+', '-', '*', '/', 'log ratio', 'overlay', 'split')
+build_collapse_function <- function(collapse_method) {
+
+  arg = match.arg(collapse_method, PE_COLLAPSE_METHODS)
+
+  if(arg %in% c('mean', 'log ratio', '+', '*')) {
+    COLL = switch(arg,
+      'mean' = colMeans,
+      '+' = colSums,
+      '*' = {
+        function(x) {apply(x, 2, prod)}
+      },
+      'log ratio' = {
+        function(x) {
+          log(apply(x, 2, function(x) {
+            Reduce(`/`, x)
+          }))
+        }
+      }
+    )
+  } else {
+    COLL = function(x) {
+      apply(x, 2, function(x) {
+        Reduce(match.fun(arg), x)
+      })
+    }
+  }
+  return (COLL)
+}
+
+PE_TRANSFORM_METHODS <- c()
+
+#
+# this function assumes the data have COL=Electrodes and ROW=variables.
+# xvars and yvars must be %OF% rownames(by_electrode_custom_plot_data)
+# colnames of by_electrode_custom_plot_data must be electrode numbers
+plot_by_electrode_custom_plot <- function(by_electrode_custom_plot_data, yvars, xvars='electrode', plot_options=NULL,
+  plot_decorations=list(),
+  collapse_xvars=PE_COLLAPSE_METHODS, collapse_yvars=PE_COLLAPSE_METHODS,
+  transfrom_xvar=PE_TRANSFORM_METHODS, transform_yvar=PE_TRANSFORM_METHODS,
+  xunit='', yunit='', do_layout=TRUE) {
+  apply_current_theme()
+
+  if(is.null(plot_options)) {
+    plot_options <- list()
+  }
+  plot_options$pch %?<-% 19
+  plot_options$pt.cex %?<-% 1
+  plot_options$x_axis_font_scale %?<-% 0.5
+  plot_options$pt.alpha %?<-% 100
+  plot_options$plot_width_scale %?<-% 1
+  plot_options$plot_height_scale %?<-% 1
+  plot_options$include0 %?<-% c('X', 'Y')
+  plot_options$matched_axes %?<-% FALSE
+
+
+  # centered, scalable layout
+  if(isTRUE(do_layout)) {
+    par(mar=c(6,6,3,3), oma=c(0,0,0,0))
+    k = plot_options$plot_width_scale
+    h = plot_options$plot_height_scale
+    layout(matrix(c(0,1,0), nrow=1), widths = c(1,lcm(25*k), 1))
+  }
+
+  x.cex = pe_graphics_settings_cache$get('rave_cex.lab')*get_cex_for_multifigure()*plot_options$x_axis_font_scale
+
+  ## create Y first, as X may depend on Y
+  if(nzchar(yunit)) {
+    prfx = paste0(yunit, '(')
+    yvars <- paste0(prfx, yvars, ')')
+  }
+  yvars = yvars[yvars %in% rownames(by_electrode_custom_plot_data)]
+  .Y = by_electrode_custom_plot_data[yvars[1],]
+  if(length(yvars) > 1) {
+    collapse_yvars=match.arg(collapse_yvars)
+    .Y <- build_collapse_function(collapse_yvars) (by_electrode_custom_plot_data[yvars,])
+  }
+
+  if(any(xvars == 'electrode')) {
+    .X = seq_along(.Y)
+  } else {
+    if(nzchar(xunit)) {
+      prfx = paste0(xunit, '(')
+      xvars <- paste0(prfx, xvars, ')')
+    }
+
+    xvars = xvars[xvars %in% rownames(by_electrode_custom_plot_data)]
+    .X = by_electrode_custom_plot_data[xvars[1],]
+
+    if(length(xvars) > 1) {
+      collapse_xvars=match.arg(collapse_xvars)
+      .X <- build_collapse_function(collapse_xvars) (by_electrode_custom_plot_data[xvars,])
+    }
+  }
+
+  # create a pretty axis label
+  build_str <- function(vars, coll) {
+    if(length(vars) == 1) return (vars)
+
+    if(any(vars == 'electrode')) return ('Electrode')
+
+    res <- switch(coll,
+      'mean' = paste0('mean (', paste(vars, collapse=','),')'),
+      'log ratio' = paste0('log (', paste(vars, collapse=' / '),')'),
+      paste0(vars, collapse=sprintf(' %s ', coll))
+    )
+
+    return(res)
+  }
+
+  xlim = pretty(.X)
+  ylim = pretty(.Y)
+  if ('X' %in% plot_options$include0) xlim %<>% c(0,.X)
+  if ('Y' %in% plot_options$include0) ylim %<>% c(0,.Y)
+  if (plot_options$matched_axes) {
+    xlim = ylim = range(xlim,ylim)
+  }
+  rutabaga::plot_clean(xlim,ylim)
+
+  if(is.matrix(.Y)) {
+    apply_ii(.Y, 2, function(yy, ii) {
+      points(.X, yy, pch=plot_options$pch, cex=plot_options$pt.cex*get_cex_for_multifigure(),
+        col=adjustcolor(ii, alpha.f = plot_options$pt.alpha/100), xpd=TRUE)
+    })
+  } else {
+    points(.X, .Y, pch=plot_options$pch, cex=plot_options$pt.cex*get_cex_for_multifigure(),
+      col=adjustcolor(1, alpha.f = plot_options$pt.alpha/100), xpd=TRUE)
+  }
+
+  rave_axis_labels(build_str(xvars, collapse_xvars), build_str(yvars, collapse_yvars), push_X = 2, push_Y = 1)
+
+  ## X axis is electrode, so we need to be careful how we plot
+  if(any(xvars == 'electrode')) {
+    # rave_axis(1, axTicks(1), labels = colnames(by_electrode_custom_plot_data)[axTicks(1)])
+    ee = as.integer(colnames(by_electrode_custom_plot_data))
+
+    str = dipsaus::deparse_svec(ee)
+    tcks <- stringr::str_split(str, ',', simplify = TRUE)
+    unlist(apply(tcks, 2, function(tck) {
+      begin_end <- as.integer(stringr::str_split(tck, '-', simplify = TRUE))
+
+      if(length(begin_end) > 1 && diff(begin_end) > 5) {
+        begin_end = sort(c(begin_end, ceiling(median(begin_end))))
+      }
+
+      rave_axis(1, which(ee %in% begin_end), labels=NA)
+      begin_end
+    })) -> all_ticks
+
+    mtext(all_ticks, side=1, at=which(ee %in% all_ticks), line=1.5,
+      cex=x.cex)
+  } else {
+
+    rave_axis(1, axTicks(1), line = 1.75, cex.axis=x.cex)
+  }
+
+  rave_axis(2, axTicks(2))
+
+  if(length(plot_decorations) > 0) {
+    dec <- get_plot_decorators()
+    sapply(dec[plot_decorations], function(FUN) {
+      FUN(x=.X, y=.Y)
+    })
+  }
+
+}
+
+get_plot_decorators <- function(names_only=FALSE) {
+  pds <- list(
+    'href' = function(x, ..., h=0, col=par('fg'), lty=1, lwd=1) {
+      # abline(h=h, lty=lty, col=col, lwd=1)
+      # sometimes abline goes too far for categorical-esque x axes, reign it in
+      # to only go to the max X value or the largest x-tick
+      segments(x0=par('usr')[1], x1=max(x, axTicks(1)), y0=0, col=col, lty=lty, lwd=1)
+    },
+    'vref' = function(..., v=0, col=par('fg'), lty=1, lwd=1) {
+      abline(v=v, lty=lty, col=col, lwd=1)
+    },
+    'reg' = function(x, y, ..., col=par('fg'), lty=2, lwd=2) {
+      if(is.matrix(y)) {
+        apply_ii(y, 2, function(yy, ii) {
+          abline(lm(yy ~ x),
+            lty=lty, col=qq, lwd=2)
+        })
+      } else {
+        abline(lm(y ~ x),
+          lty=lty, col=col, lwd=2)
+      }
+    },
+    'equality' = function(..., col=par('fg'), lwd=2, lty=1) {
+      abline(0, 1, col=col, lwd=lwd, lty=lty)
+    }
+
+  )
+
+  if(names_only) return (names(pds))
+
+  return (pds)
+}
+
+plot_grouped_data <- function(mat, xvar, yvar='y', gvar=NULL, ...,
+  types = c('jitter points', 'means', 'ebar polygons'),
+  layout=c('grouped', 'overlay'), draw0=TRUE, draw0.col=NULL,
+  ylim=NULL, col=NULL, do_axes=TRUE,
+  names.pos = c('none', 'bottom', 'top'),
+  plot_options = NULL, jitter_seed=NULL, cex_multifigure_scale=TRUE,
+  just_get_ylim = FALSE, repeated_index='Trial') {
+
+  apply_current_theme()
+
+  # here we need to know about grouping var, x-axis
+  if(is.null(plot_options)) {
+    plot_options <- list()
+  }
+
+  plot_options$pch %?<-% 16
+
+  if(!is.numeric(plot_options$pt.cex)) plot_options$pt.cex <- 1
+
+  if(cex_multifigure_scale) plot_options$pt.cex = plot_options$pt.cex*get_cex_for_multifigure()
+
+  plot_options$outlier_pch %?<-% 1
+  plot_options$pt.alpha %?<-% 100
+  plot_options$line.alpha %?<-% 100
+
+
+  draw0.col %?<-% par('fg')
+
+  # treat like percent for UI, but alpha.f wants proportion
+  for(v in c('pt.alpha', 'line.alpha')) {
+    if( plot_options[[v]] > 1)
+      plot_options[[v]] = plot_options[[v]] / 100
+  }
+
+
+  types %?<-% c('jitter points', 'means', 'ebar polygons')
+
+  names.pos = match.arg(names.pos)
+
+  # removed (layout := 'stacked') because I don't know if iEEG data
+  # should ever be stacked ?
+  if(missing(xvar) && !is.null(gvar)) {
+    xvar <- gvar
+    gvar <- 'none'
+  }
+
+  if(is.null(gvar) || gvar == xvar) {
+    gvar <- 'none'
+  }
+
+  # layout = 'grouped'
+  layout = match.arg(layout)
+
+  # first step is to aggregate the data to get the means and potentially SE
+  keys <- xvar
+  if(gvar=='none') gvar=NULL
+
+  if(!is.null(gvar)) {
+    keys <- c(gvar, keys)
+  }
+
+  ## make sure all the keys are factors
+  mat[keys] %<>% lapply(as.factor)
+
+  raw <- data.table::data.table(mat)
+
+  if(!is.null(raw$is_clean) && any(!raw$is_clean)) {
+    # get the aggregate data for plotting means/se
+    clean <- raw[raw$is_clean, ]
+    agg <- clean[ , list(y=mean(get(yvar)), se=rutabaga:::se(get(yvar)), sd=sd(get(yvar)), n=.N), keyby=keys]
+
+  } else {
+    # print('no is_clean')
+    # if is_clean is null, we need to create it and set them to TRUE.
+    raw$is_clean = TRUE
+
+    # get the aggregate data for plotting means/se
+    agg <- raw[ , list(y=mean(get(yvar)), se=rutabaga:::se(get(yvar)), sd=sd(get(yvar)), n=.N), keyby=keys]
+  }
+
+  # make sure the xvar is a factor so that the order of the variables is preserved correctly
+  # convert y into a matrix for plotting
+  if(is.null(gvar)) {
+    agg[[xvar]] %<>% as.factor
+
+    means <- matrix(agg$y, ncol=1)
+    names.arg = levels(as.factor(agg[[xvar]]))
+
+    if('overlay' == layout) {
+      names.arg=NA
+    }
+  } else {
+    agg[[gvar]] %<>% as.factor
+
+    means <- matrix(agg$y, ncol=nlevels(as.factor(agg[[gvar]])))
+    names.arg = levels(as.factor(agg[[gvar]]))
+  }
+
+  # color is based on rows of means
+  # col <-  seq_len(nrow(means))
+  col %?<-% seq_len(nrow(means))
+
+  # in case we have a caller-supplied col but it's the wrong length
+  if(length(col) < nrow(means)) {
+    col %<>% rep(length.out=nrow(means))
+  }
+
+  bp_clean <- function(...) {
+    my_args <- list(axes=F, ylab='', xlab='', border=NA,
+      beside = layout=='grouped',
+      # cex.axis=1*get_cex_for_multifigure(),
+      cex.names = pe_graphics_settings_cache$get('rave_cex.lab')*get_cex_for_multifigure()
+    )
+    your_args <- list(...)
+    if(length(your_args) > 0) {
+      my_args[names(your_args)] <- your_args
+    }
+
+    do.call(barplot, my_args)
+  }
+
+  # we want to use barplot to create the window because it has nice xlim and ylim padding
+  # but if we're adding points / ebars we need to consider that at creation time
+  # ylim=NULL
+  tmp_y <- ylim
+  if(is.null(tmp_y)) {
+    tmp_y <- if(any(c('ebar polygons', 'ebars') %in% types)) {
+      range(rutabaga::plus_minus(agg$y, agg$se))
+    } else {
+      range(agg$y)
+    }
+
+    if('sd polygons' %in% types) {
+      tmp_y <- range(rutabaga::plus_minus(agg$y, agg$sd))
+    }
+
+    if (any(c('points', 'jitter points', 'connect points',
+      'densities', 'density polygons', 'rugs') %in% types)) {
+      tmp_y %<>% range(raw[[yvar]]*1.1)
+    }
+
+    # ensure start at 0 if doing true barplot
+    if(any(c('bars', 'borders') %in% types)) {
+      tmp_y %<>% range(0)
+    }
+    tmp_y <- range(pretty(tmp_y), tmp_y)
+  }
+
+  # first create the empty plot. the trick here is that we're
+  # giving barplot data with the same dimension of means but with the appropriate
+  # range
+  ylim %?<-% range(tmp_y, pretty(tmp_y))
+
+  if(isTRUE(just_get_ylim)) {
+    return(ylim)
+  }
+
+  # NB: heights could end up a 1x1 matrix w/o the appropriate range
+  bars.x <- bp_clean(array(tmp_y, dim=dim(means)), col=par('bg'), names.arg=names.arg, ylim=ylim, ...)
+
+  if(!is.matrix(bars.x)) {
+    if(layout == 'grouped') {
+      warning("layout is grouped but I don't have grouped coordinates... bail!")
+      return(FALSE)
+    }
+    bars.x %<>% matrix(nrow = nrow(means), ncol=ncol(means), byrow=T)
+  }
+
+  if(draw0) abline(h=0, col=draw0.col)
+
+  # in case you're looping over agg, you'll want this
+  long_col <- rep(col, times=ncol(bars.x))
+  # for jittering and other l/r movement
+  r <- if(length(bars.x) == 1) {
+    1/4
+  } else if(nrow(bars.x) == 1) {
+    (1/4) * min(diff(c(bars.x)))
+  } else {
+    if ('overlay' == layout && ncol(bars.x) > 1) {
+      (1 / 4) * min(diff(t(bars.x)))
+    } else {
+      (1/4) * min(diff(bars.x))
+    }
+  }
+  if(any(r==0, is.infinite(r))) {r <- 1/4}
+
+  #keep the data together so we can check outlier status later
+  points_list <- split(raw, by=keys)# %>% lapply(`[[`, yvar)
+
+  # we need to make sure the points_list respects the factor ordering
+  if(is.null(gvar)) {
+    ord <- levels(as.factor(mat[[xvar]]))
+  } else {
+    # sapply(keys, function(k) is.factor(mat[k]))
+    # class(mat$Factor1)
+
+    sapply(keys, function(k) is.factor(mat[[k]]))
+    mat[keys] <- lapply(mat[keys], as.factor)
+
+    ord <- stringr::str_replace_all(levels(do.call(`:`, mat[,keys])), ':', '.')
+  }
+  points_list <- points_list[ord]
+
+
+  # helper function to determine location of x-position for points
+  .get_x <- if('jitter points' %in% types) {
+    # here we shrink r so that the points stay w/n r after plotting (non-zero point size)
+    function(pl, bx) density_jitter(pl[[yvar]], around = bx,
+      max.r = 0.7*r, seed = jitter_seed)
+  } else {
+    function(pl, bx) rep(bx, length(pl[[yvar]]))
+  }
+
+  points_list.x <- mapply(.get_x, points_list, bars.x, SIMPLIFY = FALSE)
+
+  ### BARS
+  if (any(c('bars', 'borders') %in% types)) {
+    # I think we should be using long_col here
+    bar.col = adjustcolor(long_col, .7)
+    bar.border = long_col
+    if(!('bars' %in% types)) {
+      bar.col = rep(NA, length(bar.col))
+    }
+    if(!('borders' %in% types)) {
+      bar.border = rep(NA, length(bar.border))
+    }
+
+    # if type is overlay, then we need to draw these on top of each other
+    if('overlay' == layout) {
+      mapply(function(row, col, border) {
+        bp_clean(height=means[row, ], col=col, border=border, add=TRUE
+          # ,space=0.5
+        )
+      }, seq_len(nrow(means)), bar.col, bar.border)
+    } else {
+      # stacked and grouped are handled cleanly by bp_clean
+      xp <- bp_clean(height = means, col=bar.col, border=bar.border, add=TRUE,
+        plot=FALSE)
+
+      if(length(xp)==1) {
+        half_window <- r[1]*diff(par('usr')[1:2])
+        polygon(c(xp[1] - half_window, xp[1] + half_window,
+          xp[1] + half_window, xp[1] - half_window),
+          y = c(0,0,means[1], means[1]),
+          border=bar.border, col=bar.col)
+      } else { #if(ncol(xp)==1) {
+        half_window <- r[1]*unique(diff(xp[,1]))[1]
+        sapply(seq_along(xp), function(xi) {
+
+          polygon(c(xp[xi] - half_window, xp[xi] + half_window,
+            xp[xi] + half_window, xp[xi] - half_window),
+            y = c(0,0,means[xi], means[xi]),
+            border=bar.border[xi], col=bar.col[xi])
+        })
+
+      }
+    }
+  }
+
+  ## DENSITIES
+
+  if('density polygons' %in% types) {
+    for(ii in seq_along(points_list)) {
+      if(length(points_list[[ii]][[yvar]]) > 1) {
+        dx <- density(points_list[[ii]][[yvar]], n=64)
+        dx$y <- r*(dx$y/max(dx$y))
+        polygon(x = c(bars.x[ii] + dx$y, rev(bars.x[ii] -dx$y), bars.x[ii]+ dx$y[1]),
+          c(dx$x, rev(dx$x), dx$x[1]),
+          border = NA, col=adjustcolor(long_col[ii], .3), lwd=1.5)
+      }
+    }
+  }
+
+  if('densities' %in% types) {
+    for(ii in seq_along(points_list)) {
+      if(length(points_list[[ii]][[yvar]]) > 1) {
+        dx <- density(points_list[[ii]][[yvar]], n=64)
+        dx$y <- r*(dx$y/max(dx$y))
+        for(k in c(-1,1)) lines(bars.x[ii] + k*dx$y, dx$x,
+          col=adjustcolor(long_col[ii], .8), lwd=1.5)
+      }
+    }
+  }
+
+  if('connect points' %in% types && anyDuplicated(raw[[repeated_index]])) {
+    # need to determine which points to connect.
+
+    # connect points based on trial column
+    if(layout=='grouped') {
+      # repeated_index = 'Trial'
+
+      by_trial <- mapply(function(x,y) {
+        cbind('x'=x, y)
+      }, points_list.x, points_list, SIMPLIFY = FALSE) %>% rbind_list %>% split((.)[[repeated_index]])
+
+      sapply(by_trial, function(tt) {
+        col = ifelse(length(unique(tt[[xvar]]))==1, as.integer(tt[[xvar]][1]), 'gray70')
+
+        # don't connect the points across levels of a grouping var
+        if(!is.null(gvar)) {
+          .rle <- rle(as.character(tt[[gvar]]))
+
+          for(rr in seq_along(.rle$lengths)) {
+            if(rr == 1) {
+              ind = 1:(.rle$lengths[1])
+            } else {
+              ind = (cumsum(.rle$lengths)[rr-1] + 1) : cumsum(.rle$lengths)[rr]
+            }
+            lines(tt$x[ind], tt[[yvar]][ind], col=adjustcolor(col, alpha.f = plot_options$line.alpha))
+
+          }
+
+        } else {
+          lines(tt$x, tt[[yvar]], col=adjustcolor(col, alpha.f = plot_options$line.alpha))
+        }
+
+      })
+    }
+  }
+
+  if('rugs' %in% types) {
+    warning('rugs not implemented')
+    # mapply(function(x, pts, clr) {
+    #     d <- diff(grconvertY(1:2, from='lines', to='user'))
+    #
+    #     if(any(duplicated(y))) {
+    #         y %<>% jitter
+    #     }
+    #
+    #     lapply(pts$y, function(y) segments(x0=x-d, x+d, y0=y, col=clr))
+    #
+    # }, bars.x, points_list, col)
+  }
+
+  if(any(c('points', 'jitter points') %in% types)) {
+    # go through each row in agg and select out the appropriate points from raw
+    # we need to make sure mat is sorted before we do this
+
+    if(length(points_list) == length(bars.x)){
+      points_list.x %?<-% mapply(.get_x, points_list, bars.x, SIMPLIFY = FALSE)
+
+      mapply(function(x, pl, clr) {
+        points(x, pl[[yvar]], col=adjustcolor(clr, alpha.f = plot_options$pt.alpha),
+          pch=ifelse(pl$is_clean, plot_options$pch, plot_options$outlier_pch),
+          cex = plot_options$pt.cex, xpd=TRUE)
+      }, points_list.x, points_list, long_col)
+
+    } else {
+      warning("couldn't line up points with bars... sorry!")
+    }
+  }
+
+  # now do error bars if possible
+  if('ebars' %in% types) {
+    # check if we're horizontal or not
+    # if(horizontal) {
+    #   ebars.x(...)
+    #} else {
+
+    rutabaga::ebars(bars.x, agg$y, sem = agg$se, code=0, col=col, lwd=2)
+    #}
+  }
+
+  if('ebar polygons' %in% types) {
+    for(ii in 1:nrow(agg)) {
+      rutabaga::do_poly(
+        rutabaga::plus_minus(x = bars.x[ii], d = r),
+        # bars.x[ii] %>% plus_minus(r),
+        rutabaga::plus_minus(x = agg$y[ii], d = agg$se[ii]),
+        # y = agg$y[ii] %>% plus_minus(agg$se[ii]),
+        col = long_col[ii], alpha = .3*255)
+    }
+  }
+
+  if('sd polygons' %in% types) {
+    for(ii in 1:nrow(agg)) {
+      rutabaga::do_poly(
+        rutabaga::plus_minus(x = bars.x[ii], d = r),
+        # bars.x[ii] %>% plus_minus(r),
+        rutabaga::plus_minus(x = agg$y[ii], d = agg$sd[ii]),
+        # y = agg$y[ii] %>% plus_minus(agg$se[ii]),
+        col = long_col[ii], alpha = .3*255)
+    }
+  }
+
+
+
+  if ('connect means' %in% types) {
+    # I think if we are grouped, then we don't allow the lines to go across the groups
+    if(layout == 'grouped') {
+      for(ii in seq_len(ncol(means))) {
+        lines(x=bars.x[,ii], means[,ii], col='black', type='l', lwd=2)
+      }
+    } else {
+      # for overlay, we go across the groups
+      for(ii in seq_len(nrow(means))) {
+        lines(x=bars.x[ii,], means[ii,], col=col[ii], type='l', lwd=2)
+      }
+
+      # but if there are no groups.... then go over whatever we can?
+      # I think this will make people happy; it's confusing to add an option
+      # and have it do nothing. If it does the wrong thing we can "change" it. If
+      # it does nothing, it looks broken and we have to "fix"
+      if(ncol(means)==1) {
+        lines(x=bars.x[,1], means[,1], col='black', type='l', lwd=2)
+      }
+
+    }
+  }
+
+  if('means' %in% types) {
+    segments(bars.x - r, x1=bars.x + r, y0 = means, col=long_col, lwd=2, lend=1)
+  }
+
+  if(do_axes) {
+    rave_axis(2, at=axTicks(2))
+  }
+
+  xlevels = length(unique(raw[[xvar]]))
+  if(names.pos != 'none') {
+    y = if(names.pos == 'top') {
+      par('usr')[4] + 0.05 * diff(par('usr')[3:4])
+    } else {
+      par('usr')[3] - 0.025 * diff(par('usr')[3:4])
+    }
+
+    lbls = levels(as.factor(raw[[xvar]]))
+    if(xvar == 'Factor1Factor2') {
+      lbls = stringr::str_replace_all(lbls, '\\.', '\n')
+    }
+    text(c(bars.x)[seq_len(xlevels)], y=rep(y, xlevels),
+      labels=lbls,
+      col = col, xpd=TRUE,
+      cex = pe_graphics_settings_cache$get('rave_cex.lab')*get_cex_for_multifigure())
+  }
+
+
+  return(invisible(list(x=points_list.x, y=points_list, bars.x=bars.x)))
+}
+
+density_jitter <- function(x, around=0, max.r=.2, n=length(x), seed=NULL) {
+  if(n < 2) {
+    return(around)
+  }
+  dx <- density(x, from=min(x), to=max(x), n=n)
+
+  # careful here, switching from x to y (i.e., y = f(x))
+  y <- approxfun(dx)(x)
+
+  R.utils::withSeed({
+    runif(length(x),
+      min = -max.r * (y/max(y)),
+      max = max.r * (y/max(y))
+    ) + around
+
+  }, seed = seed)
+}
+
+build_heatmap_analysis_window_decorator <- function(...,  type=c('line', 'box'),
+  lwd=2, lty=2,
+  active_adjust=0.5,
+  tmp_lty=4,
+  show_top_label=FALSE) {
+  force(lwd); force(lty); force(show_top_label)
+  type = match.arg(type)
+
+  # make sure we have enough space to write into
+  par('oma' = pmax(c(1,0,0,0), par('oma')))
+
+  if(! active_adjust %within% 0:1) {
+    active_adjust = 0.5
+  }
+
+  tmp_color = (1/255) * c(active_adjust * col2rgb(par('fg')) +
+      (1-active_adjust) * col2rgb(par('bg')))
+  tmp_color <- do.call(rgb, as.list(tmp_color))
+
+  hawd <- function(data, Xmap, Ymap, ...) {
+    # label analysis event
+    mtext(data$analysis_event, side = 1, at=Xmap(0),
+      line=2.5, cex=(7/8)*get_cex_for_multifigure(), col = par('fg'))
+
+    # label analysis window
+    xx <- c(-0.5, .5) + map_indices_within(data$analysis_window, data$x)
+
+    if(type == 'box') {
+      yy <- c(-0.5, 0.5) + map_indices_within(data$analysis_frequency, data$y)
+
+      if(!is.null(data$analysis_window_tmp) && !is.null(data$analysis_frequency_tmp)) {
+        polygon(c(xx,rev(xx)), rep(yy, each=2),
+          lty=lty, lwd=lwd,border=tmp_color)
+
+        xxnew <- c(-0.5, .5) + map_indices_within(data$analysis_window_tmp, data$x)
+        yynew <- c(-0.5, .5) + map_indices_within(data$analysis_frequency_tmp, data$y)
+
+        polygon(c(xxnew,rev(xxnew)), rep(yynew, each=2),
+          lwd=tmp_lty,border=par('fg'), lty=3)
+      } else {
+        polygon(c(xx,rev(xx)), rep(yy, each=2),
+          lty=lty, lwd=lwd,border=par('fg'))
+      }
+
+
+    } else {
+      abline(v=xx, lty=2, col=par('fg'), xpd=FALSE, lwd=2)
+      if(show_top_label)
+        mtext(data$analysis_group, side=3, at=xx[1], adj = -.25, line=0,
+          cex=get_cex_for_multifigure()*9/8)
+    }
+  }
+
+  return (hawd)
+}
+
+build_axis_label_decorator <- function(..., doX=TRUE, doY=TRUE, push_X=0, push_Y=0) {
+  doX = force(doX)
+  doY = force(doY)
+
+  push_X %<>% force
+  push_Y %<>% force
+
+  o.mar <- par('mar')
+  if(doX) {
+    o.mar[1] <- max(o.mar[1], 5.1+push_X)
+  }
+  if(doY) {
+    o.mar[2] <- max(o.mar[2], 5.1+push_Y/2)
+  }
+  par('mar' = o.mar)
+
+  ald <- function(data, ...) {
+    # print(push_X)
+    # print(push_Y)
+    if(doX)
+      rave_axis_labels(xlab=data$xlab, push_X = push_X)
+
+    if(doY)
+      rave_axis_labels(ylab=data$ylab, push_Y=push_Y)
+  }
+
+  return(ald)
+}
+
+stack_decorators <- function(...) {
+  decorators <- lapply(list(...), match.fun)
+
+  return(function(...) {
+    lapply(decorators, function(DD) {
+      DD(...)
+    })
+  })
+}
+
+
+build_heatmap_condition_label_decorator <- function(all_maps, ...) {
+  o.mar <- par('mar')
+
+  ## make sure we have sufficient left-margin
+  max_char_count <- sapply(all_maps, function(m) {
+    nchar(unique(as.character(m$y)))
+  }) %>% unlist %>% max
+
+  mar2 <- 5.1 + max(0, (max_char_count - 5) * 0.8)
+  new_mar <- o.mar
+  new_mar[2] = max(mar2, o.mar[2])
+
+  par('mar' = new_mar)
+
+  # function that does the decorating
+  hcld <- function(data, Xmap, Ymap, ...) {
+
+    diff_cond = rle(data$y)
+    len <- diff_cond$lengths
+    cs_len <- cumsum(len)
+
+    # drop the last one because we don't need a line at the top
+    cs_len = cs_len[-length(cs_len)]
+
+    if(length(cs_len) > 0) {
+      abline(h=cs_len+0.5)
+    }
+    midpoints <- len/2 + c(0, cs_len)
+
+    mtext(diff_cond$values, side = 2,
+      at = midpoints,
+      cex = 0.8*get_cex_for_multifigure(), las=1, line = 0.25)
+
+  }
+
+  return (hcld)
+}
+
+plot_over_time_by_electrode <- function(by_electrode_tf_data) {
+  apply_current_theme()
+
+  decorators <- stack_decorators(
+    build_heatmap_analysis_window_decorator(),
+    build_axis_label_decorator(push_X=3),
+    build_title_decorator()
+  )
+
+  draw_many_heat_maps(
+    hmaps = by_electrode_tf_data,
+    PANEL.LAST = decorators
+  )
+}
+
+build_title_decorator <- function(to_include=c('analysis_group',
+  'condition_group'), sep = ' | ') {
+  force(to_include)
+  force(sep)
+
+  btd <- function(data, ...) {
+    # grab the items from what's available in data
+    ind <- which(to_include %in% names(data))
+
+    if(length(ind) < 1) {
+      # found nothing, do nothing
+      return()
+    }
+
+    if(length(ind) == 1) {
+      # one item, no separators needed
+      str = data[[to_include[[ind]]]]
+
+    } else {
+      sep = rep_len(sep, length.out = length(to_include)-1)
+
+      # grab the first item
+      str = data[[to_include[[ind[1]]]]]
+
+      # loop from 2:N
+      for(ii in seq_along(ind)[-1]) {
+
+        #grab the next item
+        nm <- to_include[[ind[ii]]]
+        val <- data[[nm]]
+
+        # just in case we have vector values, collapse them here
+        val %<>% paste0(collapse=' ')
+
+        # finally combine using requested separator
+        str %<>% paste(val, sep=sep[ind[ii-1]])
+      }
+    }
+
+    # title!
+    rave_title(str)
+  }
+
+  return (btd)
+}
+
+plot_by_frequency_correlation <- function(by_frequency_correlation_data, plot_options) {
+
+  decorators <- stack_decorators(
+    build_axis_label_decorator(push_X = 1.5),
+    build_title_decorator()
+  )
+
+  par(pty='s')
+
+  args <- list(
+    hmaps = by_frequency_correlation_data,
+    PANEL.LAST = decorators,
+    PANEL.COLOR_BAR = color_bar_title_decorator
+  )
+
+  if(length(plot_options) > 0) {
+    args[names(plot_options)] = plot_options[names(plot_options)]
+  }
+
+  do.call(draw_many_heat_maps, args)
+
+}
+
+plot_by_frequency_over_time <- function(by_frequency_over_time_data, plot_args=list()) {
+  decorators <- stack_decorators(
+    build_heatmap_analysis_window_decorator(type = 'box'),
+    build_axis_label_decorator(push_X = 3),
+    build_title_decorator()
+  )
+
+  args <- list(
+    hmaps = by_frequency_over_time_data,
+    PANEL.LAST = decorators,
+    PANEL.COLOR_BAR = color_bar_title_decorator
+  )
+
+  if(length(plot_args) > 0) {
+    args[names(plot_args)] = plot_args[names(plot_args)]
+  }
+
+  do.call(draw_many_heat_maps, args)
+}
+
+color_bar_title_decorator <- function(m, cex = 1){#rave_cex.lab * 0.8) {
+  rave_title(paste0('Range\n[',
+    paste0(pretty_round(rutabaga::get_data_range(m)), collapse = ':'),
+    ']'),
+    font = 1,
+    cex = cex, adj = .9)
+}
+
+
+plot_by_condition_by_trial <- function(by_condition_by_trial_data,
+  grouped_plot_options, ylab='',
+  highlight_trials=NULL, do_layout=TRUE, do_axes=TRUE, ...) {
+  apply_current_theme()
+
+  # help people out if they're not in shiny
+  if(missing(grouped_plot_options)) {
+    grouped_plot_options <- list(
+      'xvar' = 'Factor1',
+      'gvar' = 'AnalysisLabel',
+      'yvar' = 'y',
+      'basic_unit' = 'Trials',
+      'panelvar' = 'none',
+      'plot_options' = list('pt.alpha' = 100, 'pt.cex' = 1),
+      'types' = c('jitter points', 'means', 'ebar polygons'),
+      'jitter_seed' = Sys.time(),
+      'plot_width_scale' = 1,
+      'highlight_clicks' = c('labels'),
+      'highlight_text_location' = 'top'
+    )
+
+    ll = list(...)
+
+    grouped_plot_options[names(ll)] <- ll
+  }
+
+  po <- grouped_plot_options
+
+  # based on shiny input, change xvar/yvar
+  # fix the names of xvar and gvar
+  for(nm in c('xvar', 'gvar', 'panelvar')) {
+    if(po[[nm]] == 'First Factor') po[[nm]] = 'Factor1'
+    if(po[[nm]] == 'Second Factor') po[[nm]] = 'Factor2'
+    if(po[[nm]] == 'First:Second') po[[nm]] = 'Factor1Factor2'
+    if(po[[nm]] == 'Analysis Group') po[[nm]] = 'AnalysisLabel'
+  }
+
+  ### setup plot size
+  k = 8 + 2.5*(count(by_condition_by_trial_data$Factor1)*count(by_condition_by_trial_data$AnalysisLabel)-1)
+  if(!is.null(by_condition_by_trial_data$Factor2)) {
+    k = k + 2.5 * (count(by_condition_by_trial_data$Factor2)-1)
+  }
+
+  MAX = 30
+  ct= count(by_condition_by_trial_data[[po$panelvar]])
+
+  nr = ct %/% 4  + 1
+  m = matrix(seq_len(ct), nrow=nr, byrow = TRUE)
+  if(do_layout) {
+
+    layout(cbind(0,m,0),
+      widths = c(1,
+        rep(lcm(po$plot_width_scale*min(k, MAX)/ct), ncol(m))
+        ,1))
+  }
+
+  # remove plot_width scale so it doesn't mes things up later
+  po$plot_width_scale = NULL
+
+  #group label position
+  label_position = 'top' #c('none', 'bottom', 'top')
+
+  # we need to collapse over electrode, but first
+  # select out the electrodes that are requested for analysis.
+  # by default, omnibus has all of the data
+  nms <- names(by_condition_by_trial_data)
+
+  # are we collapsing to trials or electrodes?
+  # REMOVE the names you want to collapse over
+  # if('Trials' == po$basic_unit) {
+  #   nms <- nms[!(nms %in% c('y', 'Electrode', 'currently_selected', 'Block'))]
+  # } else if ('Electrodes' == po$basic_unit) {
+  #   nms <- nms[!(nms %in% c('y', 'Trial', 'currently_selected', 'Block'))]
+  # }
+
+  keys = unique(c(po$xvar, po$gvar, po$panelvar, 'is_clean',
+    ifelse(po$basic_unit=='Trials', 'Trial', 'Electrode')))
+
+  keys = keys[keys!='none']
+
+  # save a copy, but then delete the one in the list. we need this to know
+  # whether we can flag particular points later
+  basic_unit <- po$basic_unit
+  po$basic_unit = NULL
+
+  oom <- get_order_of_magnitude(median(abs(pretty(by_condition_by_trial_data$y))))
+  line = 2.75 + oom
+  par('mar'= .1 + c(4, 5+oom, ifelse(label_position=='top',3.5,2), 2))
+
+  mat = data.table::data.table(by_condition_by_trial_data)
+
+  # here we're relying is_clean existing, which may not be the case if people give us weird data
+  if(is.null(mat$is_clean)) {
+    mat$is_clean = TRUE
+  }
+  mat = mat[by_condition_by_trial_data$currently_selected, list(y=mean(get('y'))), keyby=keys]
+
+  # grab the highlight variables from the plot options var
+  highlight_options <- po$highlight_clicks
+
+  htl_map = list('center' = NULL, 'bottom'=1, 'left' = 2, 'top' = 3, 'right'=4)
+  if(isTRUE(po$highlight_text_location %in% names(htl_map))) {
+    highlight_text_location <- htl_map[[po$highlight_text_location]]
+  } else {
+    highlight_text_location <- NULL
+  }
+
+  po$highlight_clicks <- NULL
+  po$highlight_text_location <- NULL
+
+  # we are panelling
+  if(ct > 1) {
+    par(oma=c(1,1,0,0))
+    ravedash::logger('Trying to make panels')
+    pvar <- po$panelvar
+    by_panel <- split(mat, mat[[pvar]], drop = TRUE)
+
+    ## refactor the panelling var so we don't get extra rows?
+    by_panel %<>% lapply(function(p) {
+      p[[pvar]] %<>% factor
+      p
+    })
+
+    # we need to avoid passing in the panel var to the plot function
+    po$panelvar = NULL
+
+    # before we plot, we need to figure out the ylim of the plot
+    # this is non-trivial (depends on plot options) so just use the function
+    # to get the limits
+    ylim <- sapply(by_panel, function(m) {
+      do.call(plot_grouped_data,
+        append(po, list(mat=as.data.frame(m),
+          do_axes=TRUE, names.pos=label_position, just_get_ylim=TRUE))
+      )
+    }) %>% range
+
+
+    qq <- 1
+    res <- lapply(by_panel, function(m) {
+      # m = by_panel[[1]]
+      # text(ylab, outer=TRUE, line = 1, side = 2, xpd=TRUE,
+      #       cex=get_cex_for_multifigure()*pe_graphics_settings_cache$get('rave_cex.axis'))
+
+      res <- do.call(plot_grouped_data,
+        append(po, list(mat=as.data.frame(m),
+          do_axes=do_axes, names.pos=label_position, ylim=ylim))
+      )
+
+      if(0 == ((qq-1) %%  3)) {
+        rave_axis_labels(ylab = ylab, yline=line+.5)
+        qq <<- qq + 1
+      }
+
+      mtext(unique(m[[pvar]]), outer=FALSE, line = 3.5, side = 1, xpd=TRUE,
+        cex=get_cex_for_multifigure()*pe_graphics_settings_cache$get('rave_cex.axis'))
+
+      return(res)
+    })
+
+  } else {
+    po$panelvar = NULL
+    res <- do.call(plot_grouped_data,
+      append(po, list(mat=as.data.frame(mat),
+        do_axes=do_axes, names.pos=label_position))
+    )
+
+    if(nzchar(ylab)) {
+      rave_axis_labels(ylab=ylab, outer=FALSE, yline=line, xpd=TRUE)
+    }
+
+    if(length(highlight_trials) > 0 && basic_unit == 'Trials') {
+      # unlist(res$x)
+      # rbind_list(res$y)
+
+      by_trial <- mapply(function(x,y) {
+        cbind(x,y)
+      }, res$x, res$y, SIMPLIFY = FALSE) %>% rbind_list %>% subset(Trial %in% highlight_trials) %>% split((.)$Trial)
+
+      sapply(by_trial, function(trial) {
+
+        col = ifelse(count(trial[[po$xvar]])==1, as.integer(trial[[po$xvar]])[1], 'gray70')
+
+        if('lines' %in% highlight_options) {
+          lines(trial$x, trial$y, col=col, lwd=1.5)
+        }
+        if('points' %in% highlight_options) {
+          points(trial$x, trial$y, bg='white', col=col, lwd=1.5, pch=21, cex=1.5)
+        }
+        if('labels' %in% highlight_options) {
+          text(trial$x, trial$y, trial$Trial, cex=2, pos = highlight_text_location)
+        }
+
+      })
+
+    }
+
+  }
+
+  # here we want to return the data alongside xy positions of each point to make them
+  # easy to locate later. this won't work correctly with paneled data
+  return(res)
+
+}
+
+build_outlier_decorator <- function(all_data) {
+
+  # create a short-circuit option so we don't mess with the
+  # margins unless we really need to. Putting this here instead of
+  # in the calling function because it needs to be done for every plot
+  any_outliers <- sapply(all_data, function(ad) {
+    any(ad$is_outlier)
+  }) %>% any
+
+  if(!any_outliers) {
+    return (function(...) {1})
+  }
+
+  mar = par('mar')
+  if(mar[4] < 3) mar[4] = 3
+  par('mar' = mar)
+
+  od <- function(data, Xmap, Ymap, ...) {
+
+    do_box <- function(x, y) {
+
+      .seg <- function(...) {
+        segments(..., lwd=2, col=par('fg'), lty=3, xpd=TRUE)
+      }
+      .seg(x0=x[1], y0=y[1], x1 = x[2])
+      # .seg(x0=x[2], y0=y[1], y1=y[2])
+      .seg(x0=x[1], y0=y[2], x1 = x[2])
+      # .seg(x0=x[1], y0=y[1], y1=y[2])
+    }
+
+    if(any(data$is_outlier)) {
+      xlim = c(0,length(data$x))
+
+      odd <- which(data$is_outlier)
+
+      sapply(odd, function(oddity) {
+        do_box(xlim, c(oddity-0.5, oddity+0.5))
+
+        # text(par('usr')[2]*1.1, oddity, , cex=1.2*get_cex_for_multifigure(), font=2, adj=c(1,0.5))
+      })
+
+      mtext(side=4, data$trial_number[odd], at=odd,
+        font=2, line=-1, cex=.9*get_cex_for_multifigure(), las=1)
+    }
+  }
+  return(od)
+}
+
+plot_over_time_by_trial <- function(over_time_by_trial_data, plot_options) {
+  apply_current_theme()
+
+  decorators <- stack_decorators(
+    build_title_decorator(),
+    build_heatmap_analysis_window_decorator(),
+    build_heatmap_condition_label_decorator(over_time_by_trial_data),
+    build_outlier_decorator(over_time_by_trial_data)
+  )
+
+  args <- list(
+    hmaps = over_time_by_trial_data,
+    PANEL.LAST = decorators,
+    PANEL.COLOR_BAR = color_bar_title_decorator,
+    axes=c(T,F)
+  )
+
+  if(length(plot_options) > 0) {
+    args[names(plot_options)] = plot_options[names(plot_options)]
+  }
+
+  do.call(draw_many_heat_maps, args)
+
+}
+
+plot_by_trial_look_for_outliers <- function(by_trial_look_for_outliers_data) {
+
+}
+
+plot_by_trial_assess_normality <- function(by_trial_look_for_outliers_data) {
+
+}
+
+plot_by_trial_assess_stationarity <- function(by_trial_assess_stationarity_data) {
+
+  # by_trial_assess_stationarity_data$
+
+}
+
+plot_by_trial_electrode_similarity <- function(by_trial_electrode_similarity_data) {
+
+  # by_trial_assess_stationarity_data$
+
+}
+
+
+# chdir = TRUE, current working directory is this folder
+pipeline <- raveio::pipeline(pipeline_name = "power_explorer", paths = "../..")
+pe_graphics_settings_cache <- dipsaus::rds_map(file.path(pipeline$preference_path, "graphics"))
+
+default_pegs <- {list(
+  rave_cex.main = 1.5,
+  rave_cex.axis = 1.3,
+  # putting this to 1.4 because 1.5 causes some clipping of the axis(2) label, we could also try to increase
+  # the (outer) left margin to compensate
+  rave_cex.lab = 1.4,
+  rave_axis_tcl = -0.3,
+  plot_time_range = c(-Inf,Inf),
+  draw_decorator_labels = FALSE,
+  plot_title_options = c('Subject ID', 'Electrode #', 'Condition', 'Frequency Range',
+    'Sample Size', 'Baseline Window', 'Analysis Window'),
+
+
+  ## this is now managed through ravedash theme
+  background_plot_color_hint = 'white',
+  champions_tunic = '#009edd',
+
+  line_color_palette = 'Beautiful Field',
+  invert_colors_in_palette = FALSE,
+  reverse_colors_in_palette = FALSE,
+
+  analysis_window.shade.color = 'gray70',
+  analysis_window.stroke.color = 'match',
+
+  heatmap_color_palette = get_heatmap_palette(get_palette_names = TRUE)[[1]],
+  heatmap_number_color_values = 101,
+  invert_colors_in_heatmap_palette = FALSE,
+  reverse_colors_in_heatmap_palette = FALSE,
+
+  show_outliers_on_plots = TRUE,
+
+  log_scale = FALSE,
+  max_zlim = 0,
+  percentile_range = TRUE,
+  sort_trials_by_type = 'Trial Number',
+
+  max_columns_in_figure = 3
+
+)}
+
+nm <- names(default_pegs) [!pe_graphics_settings_cache$has(names(default_pegs))]
+if(length(nm)) {
+  pe_graphics_settings_cache$mset(.list = default_pegs[nm])
+}
+
+
+as_html <- function(obj, ...) {
+  UseMethod('as_html')
+}
+
+as_html.emmGrid <- function(obj, ..., caption='') {
+  # obj <- em$contrasts
+  # obj <- em$emmeans
+
+  df <- as.data.frame(obj)
+
+  names(df) = stringr::str_replace_all(
+    names(df),
+    c('t.ratio' = 't', 'p.value' = 'p', 'emmean' = 'Est_marginal_mean')
+  )
+  df_plain <- data.frame(df)
+
+  df_plain$p %<>% format.pval(digits=2)
+
+  df_plain %<>% lapply(function(v) {
+    if (!is.numeric(v)) {
+      return(v)
+    }
+
+    format(v, digits=3)
+  }) %>% data.frame
+
+
+  re <- list()
+  tags = shiny::tags
+
+  # if('contrast' %in% names(obj@levels)) {
+  #   'Contrast from emmeans'
+  # } else {
+  #   'Est. marginal means from emmeans'
+  # }
+
+  re$table = tags$div(
+    class = 'table-responsive',
+    tags$table(
+      class = 'table table-striped table-sm',
+      tags$caption(caption, ' | ', paste0(collapse='. ', attributes(df)$mesg)),
+      tags$thead(
+        tags$tr(
+          lapply(c(colnames(df_plain)), tags$th)
+        )
+      ),
+      tags$tbody(
+        lapply(seq_len(nrow(df_plain)), function(ii){
+          v = df_plain[ii,]
+          tags$tr(lapply(v, tags$td))
+        })
+      )
+    )
+  )
+
+  re
+}
+
+
+htmltable_coefmat <- function(
+    x, caption = NULL, digits = max(3L, getOption("digits") - 2L),
+  signif.stars = getOption("show.signif.stars"),
+  signif.legend = signif.stars,
+  dig.tst = max(1L, min(5L, digits - 1L)),
+  k = 3,
+  cs.ind = 1:k, tst.ind = k + 1,
+  zap.ind = integer(),
+  nc = ncol(x),
+  P.values = NULL,
+  has.Pvalue = nc >= 4L && length(cn <- colnames(x)) &&
+    substr(cn[nc], 1L, 3L) %in% c("Pr(", "p-v"),
+  eps.Pvalue = .Machine$double.eps,
+  na.print = "NA", quote = FALSE, right = TRUE, ...
+){
+  if (is.null(d <- dim(x)) || length(d) != 2L)
+    stop("'x' must be coefficient matrix/data frame")
+  nc <- d[2L]
+  if (is.null(P.values)) {
+    scp <- getOption("show.coef.Pvalues")
+    if (!is.logical(scp) || is.na(scp)) {
+      warning("option \"show.coef.Pvalues\" is invalid: assuming TRUE")
+      scp <- TRUE
+    }
+    P.values <- has.Pvalue && scp
+  } else if (P.values && !has.Pvalue) {
+    stop("'P.values' is TRUE, but 'has.Pvalue' is not")
+  }
+
+  if (has.Pvalue && !P.values) {
+    d <- dim(xm <- data.matrix(x[, -nc, drop = FALSE]))
+    nc <- nc - 1
+    has.Pvalue <- FALSE
+  } else {
+    xm <- data.matrix(x)
+  }
+  k <- nc - has.Pvalue - ifelse (missing(tst.ind), 1, length(tst.ind))
+  if (!missing(cs.ind) && length(cs.ind) > k) {
+    stop("wrong k / cs.ind")
+  }
+  Cf <- array("", dim = d, dimnames = dimnames(xm))
+  ok <- !(ina <- is.na(xm))
+  for (i in zap.ind) xm[, i] <- zapsmall(xm[, i], digits)
+  if (length(cs.ind)) {
+    acs <- abs(coef.se <- xm[, cs.ind, drop = FALSE])
+    if (any(ia <- is.finite(acs))) {
+      digmin <- 1 + if (length(acs <- acs[ia & acs != 0]))
+        floor(log10(range(acs[acs != 0], finite = TRUE)))
+      else 0
+      Cf[, cs.ind] <- format(round(coef.se, max(1L, digits -
+          digmin)), digits = digits)
+    }
+  }
+  if (length(tst.ind))
+    Cf[, tst.ind] <- format(round(xm[, tst.ind], digits = dig.tst),
+      digits = digits)
+  if (any(r.ind <- !((1L:nc) %in% c(cs.ind, tst.ind, if (has.Pvalue) nc))))
+    for (i in which(r.ind)) Cf[, i] <- format(xm[, i], digits = digits)
+  ok[, tst.ind] <- FALSE
+  okP <- if (has.Pvalue) ok[, -nc] else ok
+  x1 <- Cf[okP]
+  dec <- getOption("OutDec")
+  if (dec != ".") x1 <- chartr(dec, ".", x1)
+  x0 <- (xm[okP] == 0) != (as.numeric(x1) == 0)
+  if (length(not.both.0 <- which(x0 & !is.na(x0)))) {
+    Cf[okP][not.both.0] <- format(xm[okP][not.both.0], digits = max(1L,
+      digits - 1L))
+  }
+  if (any(ina)) Cf[ina] <- na.print
+  if (P.values) {
+    if (!is.logical(signif.stars) || is.na(signif.stars)) {
+      warning("option \"show.signif.stars\" is invalid: assuming TRUE")
+      signif.stars <- TRUE
+    }
+    if (any(okP <- ok[, nc])) {
+      pv <- as.vector(xm[, nc])
+      Cf[okP, nc] <- format.pval(pv[okP], digits = dig.tst,
+        eps = eps.Pvalue)
+      signif.stars <- signif.stars && any(pv[okP] < 0.1)
+      if (signif.stars) {
+        Signif <- symnum(pv, corr = FALSE, na = FALSE,
+          cutpoints = c(0, 0.001, 0.01, 0.05, 0.1, 1),
+          symbols = c("***", "**", "*", ".", " "))
+        Cf <- cbind(Cf, format(Signif))
+      }
+    } else signif.stars <- FALSE
+  } else signif.stars <- FALSE
+
+  # Make Cf a table
+  # print.default(Cf, quote = quote, right = right, na.print = na.print, ...)
+  re = list()
+  tags = shiny::tags
+  rnames = rownames(Cf)
+
+  if(length(caption) != 1){
+    caption = NULL
+  }
+  sleg = ''
+  if (signif.stars && signif.legend) {
+    if ((w <- getOption("width")) < nchar(sleg <- attr(Signif, "legend"))){
+      sleg <- strwrap(sleg, width = w - 2, prefix = "  ")
+    }
+    # cat("---\nSignif. codes:  ", sleg, sep = "", fill = w + 4 + max(nchar(sleg, "bytes") - nchar(sleg)))
+    re$signif = sleg
+    sleg = tagList(
+      br(),
+      sprintf(' - Signif. codes: %s', sleg)
+    )
+  }
+
+  re$table = tags$div(
+    class = 'table-responsive',
+    tags$table(
+      class = 'table table-striped table-sm',
+      tags$caption(caption, ' ', tags$small(sleg)),
+      tags$thead(
+        tags$tr(
+          lapply(c('', colnames(Cf)), tags$th)
+        )
+      ),
+      tags$tbody(
+        lapply(seq_len(nrow(Cf)), function(ii){
+          v = c(rnames[ii], Cf[ii,]); names(v) = NULL
+          tags$tr(lapply(v, tags$td))
+        })
+      )
+    )
+  )
+
+  re
+}
+
+htmltable_mat <- function(mat, ...) {
+  re = list()
+  tags = shiny::tags
+
+  re$table = tags$div(
+    class = 'table-responsive',
+    tags$table(
+      class = 'table table-striped table-sm',
+      tags$thead(
+        tags$tr(
+          lapply(colnames(mat), tags$th)
+        )
+      ),
+      tags$tbody(
+
+        apply(mat, 1, function(m) {
+          tags$tr(
+            lapply(m, tags$td)
+          )
+        })
+      )
+    )
+  )
+  return(re)
+}
+
+
+
+

--- a/modules/power_explorer/fork-policy
+++ b/modules/power_explorer/fork-policy
@@ -7,6 +7,6 @@
 ^main\.html$
 
 [group_analysis]
-^shared/objects/(?!data_for_group)
+^shared/objects/(?!data_for_group_analysis)
 ^shared/user
 ^main\.html$

--- a/modules/power_explorer/fork-policy
+++ b/modules/power_explorer/fork-policy
@@ -1,0 +1,12 @@
+[default]
+^shared/user
+^main\.html$
+
+[minimal]
+^shared
+^main\.html$
+
+[group_analysis]
+^shared/objects/(?!data_for_group)
+^shared/user
+^main\.html$

--- a/modules/power_explorer/main.Rmd
+++ b/modules/power_explorer/main.Rmd
@@ -485,6 +485,45 @@ betfd_success <- tryCatch({
 })
 ```
 
+```{rave build_over_time_by_electrode_and_trial_data, language="R", export ="over_time_by_electrode_and_trial_data"}
+build_data <- function(data, analysis_settings, condition_group, baseline_settings, ...) {
+  dm <- dimnames(data)
+  to_keep <- sapply(c('Time', 'Electrode', 'Trial'), which.equal, names(dm))
+  res <- list(
+    data = ravetools::collapse(data, keep = to_keep),
+    xlab='Time (s)',
+    ylab='Electrode #',
+    zlab='Trial',
+    analysis_unit = baseline_settings$unit_of_analysis,
+    condition_group = condition_group$label,
+    electrodes = as.integer(dm$Electrode)
+  )
+  
+  res[c('x', 'y', 'z')] <- dimnames(data)[to_keep] %>% lapply(as.numeric)
+  dimnames(res$data) = dimnames(data)[to_keep]
+  res$N = length(dm$Trial)
+  
+  if(isTRUE(analysis_settings$censor_info$enabled)) {
+    
+    ti = res$x %within% analysis_settings$censor_info$window
+    res$range <- range(res$data[!ti,,])
+  } else {
+    res$range <- range(res$data)
+  }
+  
+  return(res)
+}
+
+over_time_by_electrode_and_trial_data <- data_builder(pluriform_power = pluriform_power,
+                                            condition_group = analysis_groups, 
+                                            baseline_settings = baseline_settings,
+                                            build_data)
+
+
+```
+
+
+
 ```{rave build_over_time_by_condition_data, language="R", export ="over_time_by_condition_data"}
 build_data <- function(dd, settings) {
   to_keep <- sapply(c('Time', 'Electrode'), which.equal, names(dimnames(dd)))
@@ -1488,6 +1527,21 @@ if(electrode_export_data_type == 'tensor') {
   )
 }
 
+```
+
+```{rave build_data_for_group_analysis, language="R", export='data_for_group_analysis'}
+
+data_for_group_analysis <- list()
+
+data_for_group_analysis$baseline_settings <- baseline_settings
+data_for_group_analysis$analysis_settings_clean <- analysis_settings_clean
+
+data_for_group_analysis$electrode_information <- subset(repository$electrode_table, repository$electrode_table$Electrode %in% repository$electrode_list)
+
+data_for_group_analysis$over_time_by_electrode_data <- over_time_by_electrode_data
+
+data_for_group_analysis$omnibus_stats <- omnibus_results$stats
+data_for_group_analysis$omnibus_data <- omnibus_results$data_with_outliers
 ```
 
 ```{r build, echo=FALSE, results='hide'}

--- a/modules/power_explorer/main.Rmd
+++ b/modules/power_explorer/main.Rmd
@@ -12,32 +12,13 @@ chunk_output_type: console
 ```{r setup, include = FALSE}
 # This code block sets up the engine environment
 # Please do not remove me
-knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
-build_pipeline <- raveio::configure_knitr()
-# For debug use, try to mimic the environment of pipeline
-# Load R scripts starting with `shared-` in R/ folder
-.project_path <- rstudioapi::getActiveProject()
-lapply(
-    list.files(
-        file.path(.project_path, "modules", "power_explorer", "R"),
-        pattern = "^shared-.*\\.R$",
-        ignore.case = TRUE,
-        full.names = TRUE
-    ),
-    function(f){
-        source(f, local = FALSE, chdir = TRUE)
-        invisible(TRUE)
-    })
-# Load variables in `settings.yaml` and expose them to the current environment
-.settings <- raveio::load_yaml(file.path(
-    .project_path, "modules",
-    'power_explorer', "settings.yaml"))
+raveio::pipeline_setup_rmd("power_explorer")
 
-list2env(as.list(.settings), envir = environment())
+options(knit_rave_pipelines = TRUE)
 ```
 
-```{rave check_load_power, language = "R", export = "repository", cue = "always"}
-proj_subj <- sprintf("%s/%s", project_name, subject_name)
+```{rave check_load_power, language = "R", export = "repository", format = "rave_prepare_power"}
+subject <- raveio::as_rave_subject(subject_id = sprintf("%s/%s", project_name, subject_code))
 
 repository <- raveio::prepare_subject_power(
   subject = subject, electrodes = loaded_electrodes, 
@@ -53,9 +34,7 @@ requested_electrodes <- requested_electrodes[requested_electrodes %in% repositor
 if(!length(requested_electrodes)){ stop("No electrode selected") }
 ```
 
-```{rave check_analysis_settings, language = "R", export = "analysis_checks_passed"}
-analysis_checks_passed = FALSE
-
+```{rave check_analysis_settings, language = "R", export = "analysis_settings_clean"}
 check_range <- function(x, lim, lbl) {
   if(!all(x %within% lim)) stop(sprintf('Requested %s [%s] not within available range [%s]', lbl, str_collapse(range(x), ':'), str_collapse(range(lim), ':')), call. = FALSE)
 }
@@ -152,34 +131,122 @@ if(is.list(trial_outliers_list)) {
   trial_outliers_list %<>% unlist
 }
 
+
+## add in the subejct code to the analysis settings
+for(ii in seq_along(analysis_settings_clean)) {
+  analysis_settings_clean[[ii]]$subject_code = subject_code
+  analysis_settings_clean[[ii]]$project_name = project_name
+}
+
 analysis_checks_passed=TRUE
 ```
 
-```{rave calculate_baseline, language = "R", export = "baselined_power", cue = "always"}
-stopifnot(analysis_checks_passed)
+```{rave calculate_baseline, language = "R", export = "baselined_power", cue = "always", format = "user-defined-r"}
+raveio::power_baseline(
+  x = repository,
+  baseline_windows = baseline_settings$window,
+  method = get_unit_of_analysis(baseline_settings$unit_of_analysis),
+  units = get_baseline_scope(baseline_settings$scope),
+  signal_type = "LFP",
+  electrodes = requested_electrodes
+)
+baselined_power <- repository$power$baselined
+```
 
-raveio::with_future_parallel({
-    raveio::power_baseline(
-        x = repository,
-        baseline_windows = unlist(baseline_settings$window[[1]]),
-        method = get_unit_of_analysis(baseline_settings$unit_of_analysis),
-        units = get_baseline_scope(baseline_settings$scope),
-        signal_type = "LFP",
-        electrodes = requested_electrodes
-    )
-})
-baselined_power <- subset(repository$power$baselined,
-    Electrode ~ Electrode %in% requested_electrodes)
+```{rave build_trial_details, language = "R", export = "trial_details"}
+# remove empty FCGs
+k = sapply(lapply(first_condition_groupings, `[[`, 'conditions'), length)
+fcgs <- first_condition_groupings[k>0]
+
+all_trials <- c(unname(unlist(lapply(fcgs, `[[`, 'conditions'))))
+ep_table <- repository$epoch$table
+
+tbl <- subset(ep_table, ep_table[[condition_variable]] %in% all_trials,
+              select=c('Trial', condition_variable))
+
+f1 <- rutabaga::rbind_list(
+  lapply(fcgs, function(ff) {
+    # ff = fcgs[[1]]
+    df = list()
+    df[[condition_variable]] =ff$conditions
+    df$Factor1 =ff$label
+    
+    as.data.frame(df)
+  })
+)
+
+trial_details <- merge(tbl, f1, by=condition_variable)
+
+if(isTRUE(enable_second_condition_groupings)) {
+  f2 <- rutabaga::rbind_list(
+    lapply(second_condition_groupings, function(ff) {
+      # ff = second_condition_groupings[[1]]
+      # data.frame('Factor2'=ff$label, 'Condition'=ff$conditions)
+      
+      df = list()
+      df[[condition_variable]] =ff$conditions
+      df$Factor2 =ff$label
+      
+      as.data.frame(df)
+    })
+  )
+  
+  trial_details %<>% merge(f2, by=condition_variable)
+}
+
+# order the trial details by trial number
+trial_details = trial_details[order(trial_details$Trial),]
+
+# put the factors in order
+trial_details$Factor1 %<>% factor(levels = sapply(fcgs, `[[`, 'label'))
+
+if(!is.null(trial_details$Factor2)) {
+  trial_details$Factor2 %<>% factor(levels = sapply(second_condition_groupings, `[[`, 'label'))
+}
+
+# add rownames to trial details to make for easy selection by trial
+rownames(trial_details) = trial_details$Trial
 ```
 
 ```{rave build_analysis_groups, language = "R", export = "analysis_groups"}
 # build the groups from the first_condition_groupings variable (eventually add in the 2 cond group)
-analysis_groups <- mapply(function(cg, ii) {
+if(isTRUE(enable_second_condition_groupings)) {
+  # remove empty FCGs
+  
+  by_group <- split(trial_details,
+                    list(trial_details$Factor1, trial_details$Factor2)
+  )
+  
+  # names(by_group)
+  # the names should be set automatically, and this way we don't have to worry
+  # about getting the order correct
+  # names(by_group) <- paste(rep(levels(trial_details$Factor1),
+  # each=nlevels(trial_details$Factor2)), levels(trial_details$Factor2), sep='.')
+  
+  analysis_groups <- vector('list', length(by_group))
+  for(ii in seq_along(by_group)) {
+    analysis_groups[[ii]] <- list(
+      label = names(by_group)[[ii]],
+      conditions = unique(by_group[[ii]]$Condition),
+      condition_per_trial = by_group[[ii]]$Condition,
+      trials = by_group[[ii]]$Trial,
+      index = ii,
+      has_trials = TRUE#,
+      # this shouldn't be requested electrodes,
+      # this should be set based on some grouping variable like ROI
+      #electrodes = requested_electrodes
+    )
+  }
+  
+  attr(analysis_groups, 'meta') <- trial_details
+  
+} else {
+  analysis_groups <- mapply(function(cg, ii) {
     trials <- c()
     if(length(cg$conditions)>0) {
-        trials <- repository$epoch$table$Trial[
-            repository$epoch$table$Condition %in% cg$conditions
-        ]
+      trials <- repository$epoch$table$Trial[
+        repository$epoch$table[[condition_variable]] %in% cg$conditions
+      ]
     }
     
     list(
@@ -190,32 +257,53 @@ analysis_groups <- mapply(function(cg, ii) {
       has_trials = length(trials) > 0#,
       # electrodes = requested_electrodes
     )
-}, first_condition_groupings, seq_along(first_condition_groupings), SIMPLIFY = FALSE)
+  }, first_condition_groupings, seq_along(first_condition_groupings), SIMPLIFY = FALSE)
+  
+  # remove groups that have no data
+  has_trials <- which(sapply(analysis_groups, `[[`, 'has_trials'))
+  analysis_groups = analysis_groups[has_trials]
+}
 
+if(length(analysis_groups) < 1) stop('No trials available in condition groups')
+
+# bring up the label as the element name for ease of use
 names(analysis_groups) <- sapply(analysis_groups, `[[`, 'label')
-
-if(!any(vapply(analysis_groups, `[[`, FALSE, 'has_trials'))) stop('No trials available in condition groups')
 ```
 
-```{rave build_pluriform_power, language = "R", export = "pluriform_power"}
+
+```{rave build_pluriform_power, language = "R", export = "pluriform_power", format = "user-defined-r"}
+# set 12 GiB export size? // set this based on RAM?
+options(future.globals.maxSize =  12 * 1024^3)
+
+# Depends on baselined_power, 
 epoch_event_types = get_available_events(repository$epoch$columns)
 
-pluriform_power <- sapply(analysis_groups, function(ag) {
-    # ag <- analysis_groups[[1]]
-    sapply(analysis_settings, function(as) {
-        # as <- analysis_settings[[1]]
-        p <- get_pluriform_power(
-            baselined_data=baselined_power,
-            trial_indices = ag$trials,
-            events = repository$epoch$table,
-            epoch_event_types = epoch_event_types,
-            trial_outliers_list=unlist(trial_outliers_list),
-            event_of_interest = as$event,
-        )
-        list('data'=p, 'settings'=as)
-    }, simplify = FALSE, USE.NAMES = TRUE)
-}, simplify = FALSE, USE.NAMES = TRUE)
+baselined_power_data <- subset(baselined_power,
+                               Electrode ~ Electrode %in% requested_electrodes)
 
+pluriform_power <- raveio::lapply_async(
+  analysis_groups,
+  callback = function(x) {
+    paste('[build_pluriform_power] working on:', x$label, 'data')
+  }, 
+  
+  FUN = function(ag) {
+    # ag = analysis_groups[[2]]
+    # for each analysis group, run through each analysis setting
+    sapply(analysis_settings_clean, function(as) {
+      # as <- analysis_settings_clean[[1]]
+      p <- get_pluriform_power(
+        baselined_data=baselined_power_data,
+        trial_indices = ag$trials,
+        events = repository$epoch$table,
+        epoch_event_types = epoch_event_types,
+        trial_outliers_list=unlist(trial_outliers_list),
+        event_of_interest = as$event,
+        sample_rate = repository$subject$power_sample_rate
+      )
+      list('data'=p, 'settings'=as, 'outliers' = trial_outliers_list)
+    }, simplify = FALSE, USE.NAMES = TRUE)
+  })
 
 # now create frequency-subsetted versions of the data
 for(gg in seq_along(pluriform_power)) {
@@ -264,43 +352,49 @@ by_frequency_over_time_data <- data_builder(pluriform_power = pluriform_power,
 
 ```{rave build_tf_correlation_data, language="R", export = "by_frequency_correlation_data"}
 
-# for each analysis settings in the overall_tf_data, get the correlation within the time window
-if(length(analysis_settings) == 1) {
-    # we only have one set of settings, so just get the correlations within each of the conditions
-    tf_correlation_data <- vector("list", length = length(overall_tf_data))
-    
-    for(ii in seq_along(tf_correlation_data)) {
-        d <- pluriform_power[[ii]][[1]]$data$shifted_clean_data
-        
-        tm <- as.numeric(dimnames(d)$Time)
-        
-        ti <- tm %within% unlist(pluriform_power[[ii]][[1]]$settings$time)
-        if(isTRUE(pluriform_power[[ii]][[1]]$settings$censor_info$enabled)) {
-            ti = ti & (tm %within% unlist(pluriform_power[[ii]][[1]]$settings$censor_info$window))
-        }
-        stopifnot(c('Frequency', 'Time') == names(dimnames(d))[1:2])
-        
-        d_collapsed <- ravetools::collapse(d[,ti,,,drop=FALSE], keep = c(2,1))
-        tf_correlation_data[[ii]] <- list(
-            data = cor(d_collapsed),
-            xlab='',
-            ylab='',
-            zlab='Pearson correlation',
-            x = as.numeric(dimnames(d)[[1]]),
-            y = as.numeric(dimnames(d)[[1]])
-        )
-        
-        
-        
-        
-        
-    }
-} else {
-    stop('>1 analysis not yet support for tf_correlation_data')
+# for each analysis settings in the by_frequency_over_time_data, get the correlation within the time window
+
+# get the average response for _each_ frequency on _each_ trial,
+# averaged across electrodes and time points within the analysis window
+
+build_data <- function(data, analysis_settings, condition_group, baseline_settings, ...) {
+  dn <- dimnames(data)
+  tm <- as.numeric(dn$Time)
+  
+  ti <- tm %within% analysis_settings$time
+  if(isTRUE(analysis_settings$censor_info$enabled)) {
+    ti = ti & !(tm %within% analysis_settings$censor_info$window)
+  }
+  rawdata <- ravetools::collapse(data[,ti,,,drop=FALSE], keep = c(3,1))
+  
+  res <- list(
+    data = cor(rawdata),
+    xlab='Frequency',
+    ylab='Frequency',
+    zlab='Pearson correlation across trials',
+    x = as.numeric(dn$Frequency),
+    y = as.numeric(dn$Frequency),
+    rawdata <- rawdata
+  )
+  res$range = range(res$data)
+  
+  return(res)  
 }
 
+by_frequency_correlation_data <- data_builder(
+  pluriform_power = pluriform_power,
+  condition_group = analysis_groups, 
+  baseline_settings = baseline_settings,
+  build_data, data_type = 'shifted_clean_data'
+)
 ```
 
+```{rave plot_bfcd, language='R', export='plot_bfcd_success'}
+plot_bfcd_success = FALSE
+# plot_by_frequency_correlation(by_frequency_correlation_data)
+
+plot_bfcd_success = TRUE
+```
 
 ```{rave build_by_trial_tf_data, language="R", export ="by_trial_tf_data"}
 build_data <- function(dd, settings) {
@@ -344,27 +438,32 @@ by_trial_tf_data <- lapply(pluriform_power, function(pp) {
 
 ```
 
-```{rave build_by_electrode_tf_data, language="R", export ="by_electrode_tf_data"}
-
-build_data <- function(dd, settings) {
-    to_keep <- sapply(c('Time', 'Electrode'), which.equal, names(dimnames(dd)))
-    res <- list(
-        data = ravetools::collapse(dd, keep = to_keep),
-        xlab='Time (s)', ylab='Electrode #', zlab='Mean ' %&% baseline_settings$unit_of_analysis
-    )
-    
-    res[c('x', 'y')] <- dimnames(dd)[to_keep] %>% lapply(as.numeric)
-    
-    res$N = length(dimnames(dd)$Trial)
-    
-    if(isTRUE(settings$censor_info$enabled)) {
-        ti = res$x %within% settings$censor_info$window
-        res$range <- range(res$data[!ti,])
-    } else {
-        res$range <- range(res$data)
-    }
-    
-    return(res)
+```{rave build_over_time_by_electrode_data, language="R", export ="over_time_by_electrode_data"}
+build_data <- function(data, analysis_settings, condition_group, baseline_settings, ...) {
+  dm <- dimnames(data)
+  to_keep <- sapply(c('Time', 'Electrode'), which.equal, names(dm))
+  res <- list(
+    data = ravetools::collapse(data, keep = to_keep),
+    xlab='Time (s)',
+    ylab='Electrode #',
+    zlab='Mean ' %&% baseline_settings$unit_of_analysis,
+    condition_group = condition_group$label,
+    electrodes = as.integer(dm$Electrode),
+    subject_code = subject_code
+  )
+  
+  res[c('x', 'y')] <- dimnames(data)[to_keep] %>% lapply(as.numeric)
+  
+  res$N = length(dm$Trial)
+  
+  if(isTRUE(analysis_settings$censor_info$enabled)) {
+    ti = res$x %within% analysis_settings$censor_info$window
+    res$range <- range(res$data[!ti,])
+  } else {
+    res$range <- range(res$data)
+  }
+  
+  return(res)
 }
 
 over_time_by_electrode_data <- data_builder(pluriform_power = pluriform_power,
@@ -388,51 +487,64 @@ betfd_success <- tryCatch({
 
 ```{rave build_over_time_by_condition_data, language="R", export ="over_time_by_condition_data"}
 build_data <- function(dd, settings) {
-    to_keep <- sapply(c('Time', 'Electrode'), which.equal, names(dimnames(dd)))
-    res <- list(
-        data = ravetools::collapse(dd, keep = to_keep),
-        xlab='Time (s)',
-        ylab='Mean ' %&% baseline_settings$unit_of_analysis,
-        zlab=NA
-    )
-    
-    # no get m_se across electrode at each time point
-    res$data <- cbind(
-        .rowMeans(res$data, nrow(res$data), ncol(res$data)),
-        sqrt(diag(fastcov2(t(res$data))) / ncol(res$data))
-    )
-    
-    res$x <- as.numeric(dimnames(dd)$Time)
-    res$y <- NA
-    res$N = length(dimnames(dd)$Electrode)
-    
-    if(isTRUE(settings$censor_info$enabled)) {
-        ti = res$x %within% settings$censor_info$window
-        res$range <- range(plus_minus(res$data[!ti,]))
-    } else {
-        res$range <- range(plus_minus(res$data))
-    }
-    
-    return(res)
+  to_keep <- sapply(c('Time', 'Electrode'), which.equal, names(dimnames(dd)))
+  res <- list(
+    data = ravetools::collapse(dd, keep = to_keep),
+    xlab='Time (s)',
+    ylab='Mean ' %&% baseline_settings$unit_of_analysis,
+    zlab=NA
+  )
+  
+  # no get m_se across electrode at each time point
+  res$data <- cbind(
+    .rowMeans(res$data, nrow(res$data), ncol(res$data)),
+    sqrt(diag(dipsaus::fastcov2(t(res$data))) / ncol(res$data))
+  )
+  
+  ind <- is.nan(res$data[,2]) | !is.finite(res$data[,2])
+  if(length(ind) > 0) {
+    res$data[ind,2] = 0
+  }
+  
+  res$x <- as.numeric(dimnames(dd)$Time)
+  res$y <- NA
+  res$N = length(dimnames(dd)$Electrode)
+  
+  if(isTRUE(settings$censor_info$enabled)) {
+    ti = res$x %within% settings$censor_info$window
+    res$range <- range(rutabaga::plus_minus(res$data[!ti,]))
+  } else {
+    res$range <- range(rutabaga::plus_minus(res$data))
+  }
+  
+  res$electrodes = dimnames(dd)$Electrode
+  
+  res$settings = settings
+  
+  return(res)
 }
 
-over_time_data <- lapply(pluriform_power, function(pp) {
-    # rm(pp) <- pluriform_power[[1]]
-    if(length(pp) == 1 || 
-            all(
-                1 == length(table(sapply(pp, function(pi) pi$settings$event))),
-                1 == length(table(sapply(pp, function(pi) str_collapse(pi$settings$frequency))))
-            )
-    ){
-        # all analysis groups have the same time=0, so we can show them on the same plot      
-        build_data(pp[[1]]$data$shifted_clean_data_Fsub, pp[[1]]$settings)
-    } else {
-        # analysis groups have different time shifts, so they can not be shown on the same plot
-        sapply(pp, function(ppa) {
-            build_data(ppa$data$shifted_clean_data_Fsub, ppa$settings)
-        }, simplify = FALSE, USE.NAMES = TRUE)
-    }
+over_time_by_condition_data <- lapply(pluriform_power, function(pp) {
+  sapply(pp, function(ppa) {
+    build_data(dd = ppa$data$shifted_clean_data_Fsub, settings = ppa$settings)
+  }, simplify = FALSE, USE.NAMES = TRUE)
 })
+
+# bring down the meta data to the plotting level for ease of use
+for(ii in seq_along(over_time_by_condition_data)) {
+  for(jj in seq_along(over_time_by_condition_data[[ii]])) {
+    over_time_by_condition_data[[ii]][[jj]]$data_label = 
+      names(over_time_by_condition_data)[[ii]]
+    
+    over_time_by_condition_data[[ii]][[jj]]$time_window_label =
+      names(over_time_by_condition_data[[ii]])[[jj]]
+  }
+}
+```
+
+```{rave plot_over_time_data, language='R', export='plot_over_time_by_condition_result', cue='always'}
+plot_over_time_by_condition_result = TRUE
+# plot_over_time_by_condition(over_time_by_condition_data, F, F)
 ```
 
 ```{rave build_scatter_bar_data, language="R", export ="scatter_bar_data"}
@@ -537,155 +649,6 @@ analysis_data <- list()
 # }
 
 analysis_data$datatype <- baseline_settings$unit_of_analysis
-```
-
-
-```{rave build_over_time_by_electrode_dataframe, language='R', export='over_time_by_electrode_dataframe'}
-over_time_by_electrode_dataframe <- NULL
-# building data for the movie viewer
-# first baseline all the electrodes
-raveio::power_baseline(
-  repository,
-  baseline_windows = baseline_settings$window,
-  method = get_unit_of_analysis(baseline_settings$unit_of_analysis),
-  units = get_baseline_scope(baseline_settings$scope),
-  signal_type = "LFP",
-  electrodes = repository$electrode_list
-)
-
-# for each condition group and for each analysis setting
-# get one value per TIME per electrode
-non_empty_groups <- which(rutabaga::get_list_elements(
-  analysis_groups, 'has_trials'))
-
-combine_if_equal <- function(ll, nms = c('Electrode', 'Time')) {
-  if(length(ll) == 1) {
-    return(ll[[1]])
-  }
-  r1 <- ll[[1]]
-  
-  for(jj in seq_along(ll)[-1]) {
-    
-    stopifnot(all(
-      dim(r1) == dim(ll[[jj]]),
-      sapply(nms, function(nm) {
-        all.equal(r1[[nm]], ll[[jj]][[nm]])
-      })
-    ))
-  }
-  r1
-  for(jj in seq_along(ll)[-1]) {
-    cn <- names(ll[[jj]])
-    to_move = setdiff(cn, nms)
-    
-    r1[to_move] = ll[[jj]][to_move]
-  }
-  
-  return(r1)
-}
-
-by_condition_group <-
-  lapply(analysis_groups[non_empty_groups],
-         function(ag) {
-           res <- lapply(analysis_settings_clean, function(as) {
-             # as = analysis_settings_clean[[1]]
-             # freq needed
-             fi <- repository$frequency %within% as$frequency
-             
-             # shift the data and subset on trials/freq
-             p <- get_pluriform_power(
-               baselined_data=repository$power$baselined[fi,,,,drop=FALSE],
-               trial_indices = ag$trials, events = repository$epoch$table,
-               epoch_event_types = get_available_events(repository$epoch$columns), trial_outliers_list=unlist(trial_outliers_list),
-               event_of_interest = as$event, final_data_only=TRUE,
-               sample_rate = repository$subject$power_sample_rate
-             )
-             
-             # make sure dimensions are what we think they are
-             stopifnot(
-               names(dimnames(p)) == c('Frequency', 'Time', 'Trial', 'Electrode')
-             )
-             
-             enames = as.integer(dimnames(p)$Electrode)
-             times = as.numeric(dimnames(p)$Time)
-             
-             m <- ravetools::collapse(p[drop=FALSE], keep = c(4,2))
-             
-             df <- data.frame(
-               reshape2::melt(m,
-                              value.name=paste(sep='_', as$label, ag$label))
-             )
-             # head(df)
-             names(df)[1:2] = c('Electrode', 'Time')
-             df$Electrode = enames[df$Electrode]
-             df$Time = times[df$Time]
-             
-             return(df)
-           })
-           
-           # confirm everything lines up
-           combine_if_equal(res)
-         }
-  )
-
-#merge the resulting datasets
-over_time_by_electrode_dataframe <- by_condition_group[[1]]
-
-if(length(by_condition_group) > 1) {
-  for(ii in seq_along(by_condition_group)[-1]){
-    over_time_by_electrode_dataframe = merge(over_time_by_electrode_dataframe,
-                                             by_condition_group[[ii]],
-                                             all=TRUE)
-  }
-}
-
-```
-
-```{rave build_over_time_by_trial, language="R", export ="over_time_by_trial_data"}
-
-build_data <- function(data, analysis_settings, condition_group, baseline_settings, ...) {
-  
-  dm <- dimnames(data)
-  
-  to_keep <- c(
-    which.equal('Time', names(dm)),
-    which.equal('Trial', names(dm))
-  )
-  
-  res <- list(
-    data = ravetools::collapse(data[,drop=FALSE], keep = to_keep),
-    x = as.numeric(dm$Time),
-    xlab='Time',
-    ylab='Trial (sorted by condition)',
-    zlab=sprintf('Mean %s', baseline_settings$unit_of_analysis)
-  )
-  
-  res$range <- range(res$data)
-  ind <- which(sapply(first_condition_groupings, `[[`, 'label')==condition_group[[1]])
-  cnds <- first_condition_groupings[[ind]]$conditions
-  
-  tt = as.numeric(dm$Trial)
-  res$y = trial_details[as.character(tt), 'Condition']
-  cf <- factor(res$y, levels = cnds)
-  ord = order(cf, tt)
-  
-  # sort the trial labels
-  res$y <- res$y[ord]
-  
-  # NB: the condition data are stored in the COLUMNS of the data, so sort appropriately
-  # this may feel odd, but this is because of how image(...) function works
-  res$data <- res$data[,ord]
-  
-  return(res)
-}
-
-over_time_by_trial_data <- data_builder(
-  pluriform_power, condition_groups = analysis_groups,
-  baseline_settings = baseline_settings,
-  BUILDER_FUN = build_data, 
-  data_type = 'shifted_clean_data_Fsub'
-)
-
 ```
 
 
@@ -1044,20 +1007,487 @@ internal_omnibus_results = list(
 
 
 ```{rave build_omnibus_results, language="R", export="omnibus_results"}
+omnibus_results = internal_omnibus_results
+
+# to prevent needless stat recalculation when the only thing that changes is
+# "requested electrodes" add in that data here in a separate block
+
+# add in currently selected information so plots are accurate
+# to selected electrodes
+rn <- 'currently_selected'
+while(rn %in% names(omnibus_results$data)) {
+  rn <- 'PWR_EXPLR_' %&% rn
+}
+
+omnibus_results$data[[rn]] = omnibus_results$data$Electrode %in% requested_electrodes
+omnibus_results$data_with_outliers[[rn]] = omnibus_results$data_with_outliers$Electrode %in% requested_electrodes
+
+
+# add in "currently active" electrodes so users can filter
+rn <- 'currently_selected'
+while(rn %in% rownames(omnibus_results$stats)) {
+  rn = 'RAVE_' %&% rn
+}
+val = matrix(nrow=1,
+             as.integer(colnames(omnibus_results$stats) %in% as.character(requested_electrodes)),
+             dimnames=list(rn))
+omnibus_results$stats %<>% rbind(val)
+```
+
+
+```{rave build_across_electrode_statistics, language="R", export="across_electrode_statistics"}
+require(data.table)
+.datatable.aware = TRUE
+
+dd <- subset(omnibus_results$data, currently_selected)
+
+# emmeans::emm_options(lmerTest.limit = 1000)
+# emmeans::emm_options(pbkrtest.limit = 1000)
+
+# seems to be faster for large models
+emmeans::emm_options(lmer.df = "satterthwaite")
+
+# Need to think about how to handle very low trial counts for a given level of a factor
+ravedash::logger('top of BAES', calc_delta = TRUE)
+# the intersect handles variables that don't exist. We'll add Trial to RE later if possible
+rand_effects <- c('Block', 'Electrode') %>% intersect(names(dd))
+
+# we don't need "Freq" or "Event" because that is part of AnalysisLabel
+fixed_effects <- c('Factor1', 'Factor2', 
+                   #'Freq', 'Event', 
+                   'AnalysisLabel') %>% intersect(names(dd))
+
+for(ff in c(rand_effects, fixed_effects)) {
+  dd[[ff]] %<>% as.factor
+}
+
+# how many effects do we have (i.e., vars with more than one unique label)
+fe <- names(which(sapply(dd[fixed_effects], nlevels) > 1))
+re <- names(which(sapply(dd[rand_effects], nlevels) > 1))
+
+# We need to add Trial as a random effect if AnalysisLabel is a
+# fixed effect because that means a trial is used twice
+if('AnalysisLabel' %in% fe) {
+  if('Block' %in% re) {
+    # if we have multiple electrodes, then we can have a block/trial, 
+    # otherwise we can only have 'Block'
+    if('Electrode' %in% re) {
+      re[which(re == 'Block')] = 'Block/Trial'
+    }
+  } else {
+    re %<>% c('Trial')
+  }
+}
+
+re_str = NULL
+if(length(re) > 0) {
+  re_str <- paste(collapse='+',
+                  sapply(re, function(x) sprintf("(1|%s)", x))
+  )
+}
+
+
+# saveRDS('~/Desktop/v.RDS', object=list('dd'=dd, 'fe'=fe, 're_str'=re_str))
+# v <- readRDS('~/Desktop/v.RDS')
+# dd <- v$dd
+# fe <- v$fe
+# re_str <- v$re_str
+
+## get means and trial counts. data.table is way faster than aggregate
+# ravedash::logger('Trying data.table collapse. checking DTA: ', data.table:::cedta(), calc_delta = TRUE)
+dt <- data.table::as.data.table(dd)
+condition_means <- dt[ ,list('y'=mean(y), 'sd' = sd(y),
+                                                        'se'=rutabaga:::se(y),'n'=.N),
+                                                  keyby=fe]
+
+ravedash::logger('got condition means', calc_delta = TRUE)
+
+# set fe to "1" (intercept only model) if there are no fixed effects. Do this 
+# after obtaining experimental means because you can't key on the number 1
+fe <- paste0(fe, collapse='*')
+if(!nzchar(fe)) { fe <- "1" }
+
+frm <- as.formula(
+  paste('y ~', paste(c(fe, re_str), collapse=' + '))
+)
+
+FUN <- ifelse(is.null(re_str), stats::lm, lme4::lmer)
+
+mod <- do.call(FUN, list(formula=frm, data=dd))
+
+
+ravedash::logger('built linear model, starting post hoc tests', calc_delta = TRUE)
+# est. marg means initial object, used by other
+# functions to get all the contrasts
+
+em <- emmeans::emmeans(
+  mod, as.formula(sprintf(" ~ %s", fe)), infer=c(F,T)
+)
+
+ravedash::logger('Got emm', calc_delta = TRUE)
+
+pairwise <- emmeans::contrast(
+  em, 'pairwise'
+)
+
+ravedash::logger('Got pairwise contrasts', calc_delta = TRUE)
+
+# here we have a chance to stratify rather than do
+# all-possible pairwise comparisons (save your alpha!)
+stratified_contrasts <- NULL
+if(length(fe) > 1) {
+  stratified_contrasts <- get_stratified_contrasts(em)
+}
+
+## get the interaction contrasts
+itx_contrasts <- NULL
+if(length(fe) == 2) {
+  nm <- paste0(fe, collapse='_')
+  
+  itx_contrasts <- list(
+    emmeans::contrast(em, interaction=c('pairwise', 'pairwise'))
+  ) %>% setNames(nm)
+  
+}
+
+if (length(fe) > 2) {
+  fe_combn <- combn(fe, 2, simplify = FALSE)
+  
+  itx_contrasts <- sapply(fe_combn, function(groups) {
+    emmeans::contrast(em,
+                      interaction=c('pairwise', 'pairwise'), by=fe[!fe %in% groups]
+    )
+  }) %>% setNames(sapply(fe_combn, paste0, collapse='.'))
+}
+
+ravedash::logger('Got other contrasts', calc_delta = TRUE)
+
+.aov <- car::Anova(mod, type=ifelse(
+  fe[1] == "1", 'III', 'II')
+)
+
+ravedash::logger('Got ANOVA', calc_delta = TRUE)
+
+across_electrode_statistics <- list(
+  condition_means = condition_means,
+  model = mod,
+  model_type = class(mod)[1],
+  aov = .aov,
+  emmeans = em,
+  pairwise_contrasts = pairwise,
+  fixed_effects = fe,
+  random_effects = re,
+  stratified_contrasts = stratified_contrasts,
+  itx_contrasts = itx_contrasts,
+  trials_not_included = sort(trial_outliers_list)
+)
+
+```
+
+```{rave build_by_trial_electrode_similarity_data, language="R", export="by_trial_electrode_similarity_data"}
+dd <- omnibus_results$data
+
+by_trial_electrode_similarity_data <- NULL
+
+if(enable_second_condition_groupings) {
+  
+} else {
+  # for each condition group, correlate the electrode responses across trials
+  by_trial_electrode_similarity_data <- 
+    lapply(split(dd, list(dd$AnalysisLabel, dd$Factor1)),
+           function(bb) {
+             bb <- bb[order(bb$Electrode, bb$Trial),]
+             
+             mat <- matrix(c(bb$y), nrow=length(unique(bb$Trial)),
+                           dimnames = list(NULL, unique(bb$Electrode)))
+             
+             cor(mat)
+           })
+}
+```
+
+```{rave build_data_for_export, language="R", export='data_for_export', cue = "always"}
+
+warning("Overlapping time/frequency windows will not be coded properly in the export file")
+
+if( getOption("knit_rave_pipelines", default = FALSE) ) {
+  list2env(list("electrodes_to_export" = repository$power$dimnames$Electrode[1]), envir = environment())
+} else {
+}
+# ravedash::logger("1024::Electrodes to export:[", electrodes_to_export, ']', level = 'warning')
+
+prog <- shidashi::shiny_progress("Building export data", max=4,
+                                 shiny_auto_close = TRUE)
+
+data_for_export = FALSE
+
+electrodes_to_keep <- dipsaus::parse_svec(electrodes_to_export, sep=',|;', connect  = ':-')
+
+electrodes_to_keep %<>% remove_from_arr(repository$power$dimnames$Electrode, `%in%`, negate=TRUE)
+
+
+## check for ROI exclusion criteria
+if(electrodes_to_export_roi_name!='none') {
+  v = if(electrodes_to_export_roi_name== 'Custom ROI') {
+    
+  } else {
+    electrodes_to_export_roi_name
+  }
+  lbls <- subset(repository$electrode_table, Electrode %in% electrodes_to_keep, select=v, drop=TRUE)
+  electrodes_to_keep = electrodes_to_keep[lbls %in% electrodes_to_export_roi_categories]
+}
+
+if(!length(electrodes_to_keep)){ 
+  stop("No electrodes were found passing all selection criteria")
+} 
+
+prog$inc("Baseline data [export loop]")
+
+## ensure the data are available
+raveio::power_baseline(
+  repository,
+  baseline_windows = baseline_settings$window,
+  method = get_unit_of_analysis(baseline_settings$unit_of_analysis),
+  units = get_baseline_scope(baseline_settings$scope),
+  signal_type = "LFP",
+  electrodes = electrodes_to_keep
+)
+
 # 
-omnibus_results <- 1
-# 
-# # first baseline all the electrodes
-# raveio::with_future_parallel({
-#   raveio::power_baseline(
-#     x = repository,
-#     baseline_windows = unlist(baseline_settings$window[[1]]),
-#     method = get_unit_of_analysis(baseline_settings$unit_of_analysis),
-#     units = get_baseline_scope(baseline_settings$scope),
-#     signal_type = "LFP",
-#     electrodes = repository$electrode_list
-#   )
-# })
+# We're ensuring in the module that the electrodes have already 
+# been baselined etc by calling run() with our requested electrodes
+# we can grab the data directly from pluriform power
+# first we work on the tensor (one per analysis setting,
+# because of potential overlap), then flatten if requested at the end
+tensors <- lapply(analysis_settings_clean, function(asc) {
+  # asc = analysis_settings_clean[[1]]
+  ravedash::logger('Working on ', asc$label)
+  
+  current_tensor = subset(repository$power$baselined, 
+                          Electrode ~ Electrode %in% electrodes_to_keep)
+  
+  # 
+  # Work on the TRIAL dimension
+  tet <- trial_export_types()
+  # first assume keeping all the trials
+  trials_to_keep = repository$power$dimnames$Trial
+  
+  # if subset requested
+  if(trials_to_export %in% c(tet$RAW_GRP, tet$CLP_GRP, tet$CLP_CND) ) {
+    trials_to_keep <- sort(
+      unique(c(unlist(sapply(analysis_groups, `[[`, 'trials'))))
+    )
+  }
+  
+  #
+  # Here we shift the data using pluriform power function
+  shifted_tensor <- get_pluriform_power(
+    baselined_data=current_tensor,
+    trial_indices = trials_to_keep,
+    events = repository$epoch$table,
+    epoch_event_types = get_available_events(repository$epoch$columns),
+    trial_outliers_list=unlist(trial_outliers_list),
+    event_of_interest = asc$event,
+    sample_rate = repository$subject$power_sample_rate,
+    final_data_only = TRUE
+  )
+  # rm(current_tensor)
+  
+  # by default dimnames are character
+  dn = lapply(dimnames(shifted_tensor), as.numeric)
+  
+  # do we need to collapse?
+  if(trials_to_export == tet$CLP_GRP) {
+    with_trials <- which_have_trials(analysis_groups)
+    
+    # note the sapply here to concat the result
+    by_group <- sapply(analysis_groups[with_trials], function(ag) {
+      # here we have to rely on dn$Trial because subsetting may have occurred
+      # vs. the original tensor
+      ind <- (dn$Trial %in% ag$trials)
+      ravetools::collapse(shifted_tensor[,,ind,,drop=FALSE], keep=c(1,2,4))
+    })
+    
+    # this loses dimnames, so add them back
+    shifted_tensor = tensor_reshape(mat = by_group, 
+                                    orig_dim = dim(shifted_tensor), pivot=3)
+    
+    dn$Trial = unname(sapply(analysis_groups[with_trials], `[[`, 'label'))
+    dimnames(shifted_tensor) = dn
+  }
+  
+  # add a name for the trial groups, the default label is
+  # taken from the Condition Column (in the epoch table)
+  attr_TrialLabel = subset(repository$epoch$table, 
+                           Trial %in% dn$Trial, 
+                           select=c('Trial', condition_variable)
+  ) %>% data.table::setorder('Trial')
+  
+  attr_TrialLabel$OrigCondition = attr_TrialLabel[[condition_variable]]
+  
+  # add trial groups if we have them  
+  for(ag in which_have_trials(analysis_groups)) {
+    ind = attr_TrialLabel$Trial %in% analysis_groups[[ag]]$trials
+    attr_TrialLabel$Condition[ind] = names(analysis_groups)[ag]
+  }
+  
+  # TIME DIMENSION
+  tmet <- time_export_types()
+  # see if any time points can be dropped
+  if(times_to_export %in% c(tmet$CLP_AWO, tmet$RAW_AWO)) {
+    ind <- dn$Time %within% asc$time
+    
+    shifted_tensor = shifted_tensor[,ind,,,drop=FALSE]
+    dn$Time = as.numeric(dimnames(shifted_tensor)$Time)
+  }
+  
+  if(times_to_export == tmet$CLP_AWO) {
+    tmp = ravetools::collapse(shifted_tensor, keep=c(1,3:4))
+    
+    dim(tmp) = c(dim(tmp), 1)
+    
+    # perm to put time dimension back in it's place
+    shifted_tensor <- aperm(tmp, c(1,4,2,3))
+    
+    # all(0==range(shifted_tensor[,1,,] - tmp[,,,1]))
+    dn$Time = asc$label
+    dimnames(shifted_tensor) = dn
+  }
+  
+  #
+  # Frequency dimension
+  fet = frequency_export_types()
+  if(frequencies_to_export %in% c(fet$CLP_AWO, fet$RAW_AWO)) {
+    ff <- dn$Frequency %within% asc$frequency
+    shifted_tensor = shifted_tensor[ff,,,,drop=FALSE]
+  }
+  dn$Frequency = as.numeric(dimnames(shifted_tensor)$Frequency)
+  
+  if(frequencies_to_export == fet$CLP_AWO) {
+    tmp = ravetools::collapse(shifted_tensor, keep = 2:4)
+    dim(tmp) = c(dim(tmp),1)
+    
+    # perm to put time dimension back in it's place
+    shifted_tensor <- aperm(tmp, c(4,1:3))
+    # all(0==range(current_tensor[1,,,] - tmp[,,,1]))
+    dn$Frequency = asc$label
+    dimnames(shifted_tensor) = dn
+  }
+  
+  ## add in the trial label last
+  # checks here to make sure nothing weird happened. 
+  if(length(attr_TrialLabel$Condition) == length(dn$Trial) &&
+     all(0 == (dn$Trial - attr_TrialLabel$Trial))) {
+    attr(shifted_tensor, 'TrialLabel') = attr_TrialLabel$Condition
+    attr(shifted_tensor, 'OrigTrialLabel') = attr_TrialLabel$OrigCondition
+    
+  } else {
+    ravedash::logger(level='warning', "Could not apply trial labels. Length mismatch between labels (", nrow(attr_TrialLabel),
+                     ") and  trials (", length(dn$Trial), "), or trial numbers didn't line up")
+  }
+  
+  return(shifted_tensor)
+})
+
+uoa = get_unit_of_analysis_varname(baseline_settings$unit_of_analysis)
+
+if(electrode_export_data_type == 'tensor') {
+  data_for_export =  mapply(function(tensor, asc) {
+    
+    dn <- dimnames(tensor)
+    
+    ## try to convert to numeric
+    dn %<>% lapply(function(d) {
+      nd <- suppressWarnings(as.numeric(d))
+      if(any(is.na(nd))) return(d) 
+      
+      nd
+    })
+    
+    res <- list(data=tensor)
+    res[names(dn)] = dn
+    
+    res$unit = uoa
+    
+    res$baseline_window = baseline_settings$window[[1]]
+    res$baseline_scope = baseline_settings$scope[[1]]
+    
+    # add in the trial label if one was calculated above
+    if(!is.null(attributes(tensor)[['TrialLabel']])) {
+      res$TrialLabel = attr(tensor, 'TrialLabel')
+      res$OrigTrialLabel = attr(tensor, 'OrigTrialLabel')
+    }
+    
+    return(res)
+  }, tensors, analysis_settings_clean, SIMPLIFY = FALSE)
+  
+  names(data_for_export) = names(analysis_settings_clean)
+  data_for_export$data_names=names(data_for_export)
+  data_for_export$type='tensor_data'
+  
+} else {
+  ## flattened data requested
+  flat_tables <- mapply(function(tensor, asc) {
+    
+    tbl <- data.table::as.data.table(
+      reshape2::melt(tensor[drop = FALSE], value.name = uoa)
+    )
+    
+    tbl$AnalysisGroup = asc$label
+    
+    # Add in necessary meta data
+    
+    # add in the trial label if one was calculated above
+    if(!is.null(attributes(tensor)[['TrialLabel']])) {
+      df <- data.table::data.table(
+        Trial = as.numeric(dimnames(tensor)$Trial),
+        TrialLabel = attributes(tensor)[['TrialLabel']],
+        OrigTrialLabel = attributes(tensor)[['OrigTrialLabel']]
+      )
+      
+      tbl %<>% merge(df, all.y=FALSE, all.x=TRUE)
+    }
+    
+    return(tbl)
+  }, tensors, analysis_settings_clean, SIMPLIFY = FALSE)
+  
+  
+  if(!data.table::is.data.table(flat_tables)) {
+    # flat_tables %<>% rbind_list
+    flat_tables <- rutabaga::rbind_list(flat_tables)
+  }
+  
+  # convert factors back to characters
+  flat_tables %<>% lapply(function(x) {
+    if(is.factor(x)) {
+      x <- as.character(x)
+    }
+    x
+  }) %>% as.data.frame
+  
+  # merge in the electrode level data
+  # this greatly increases the size of the file,
+  # but it's compressed while downloading
+  all_elecs <- as.integer(unique(
+    sapply(tensors, function(tn) dimnames(tn)$Electrode)
+  ))
+  
+  et <- subset(repository$electrode_table, Electrode %in% all_elecs)
+  
+  flat_tables %<>% merge(et)
+  
+  data_for_export = list(
+    type='flat_data',
+    data_names = 'all_data',
+    all_data = list(data=flat_tables),
+    metadata=list(
+      unit = uoa,
+      baseline_window = paste0(collapse=':', baseline_settings$window[[1]]), 
+      baseline_scope = baseline_settings$scope[[1]]
+    )
+  )
+}
+
 ```
 
 ```{r build, echo=FALSE, results='hide'}

--- a/modules/power_explorer/make-power_explorer.R
+++ b/modules/power_explorer/make-power_explorer.R
@@ -17,90 +17,90 @@ rm(._._env_._.)
     quote({
         yaml::read_yaml(settings_path)
     }), deps = "settings_path", cue = targets::tar_cue("always")), 
-    input_electrode_export_data_type = targets::tar_target_raw("electrode_export_data_type", 
+    input_electrodes_to_export_roi_categories = targets::tar_target_raw("electrodes_to_export_roi_categories", 
         quote({
-            settings[["electrode_export_data_type"]]
-        }), deps = "settings"), input_electrodes_to_export = targets::tar_target_raw("electrodes_to_export", 
-        quote({
-            settings[["electrodes_to_export"]]
-        }), deps = "settings"), input_trials_to_export = targets::tar_target_raw("trials_to_export", 
-        quote({
-            settings[["trials_to_export"]]
-        }), deps = "settings"), input_times_to_export = targets::tar_target_raw("times_to_export", 
-        quote({
-            settings[["times_to_export"]]
-        }), deps = "settings"), input_frequencies_to_export = targets::tar_target_raw("frequencies_to_export", 
-        quote({
-            settings[["frequencies_to_export"]]
-        }), deps = "settings"), input_electrode_export_file_type = targets::tar_target_raw("electrode_export_file_type", 
-        quote({
-            settings[["electrode_export_file_type"]]
-        }), deps = "settings"), input_trial_outliers_list = targets::tar_target_raw("trial_outliers_list", 
-        quote({
-            settings[["trial_outliers_list"]]
-        }), deps = "settings"), input_time_censor = targets::tar_target_raw("time_censor", 
-        quote({
-            settings[["time_censor"]]
-        }), deps = "settings"), input_project_name = targets::tar_target_raw("project_name", 
-        quote({
-            settings[["project_name"]]
-        }), deps = "settings"), input_subject_code = targets::tar_target_raw("subject_code", 
-        quote({
-            settings[["subject_code"]]
-        }), deps = "settings"), input_loaded_electrodes = targets::tar_target_raw("loaded_electrodes", 
-        quote({
-            settings[["loaded_electrodes"]]
-        }), deps = "settings"), input_epoch_choice = targets::tar_target_raw("epoch_choice", 
-        quote({
-            settings[["epoch_choice"]]
-        }), deps = "settings"), input_epoch_choice__trial_starts = targets::tar_target_raw("epoch_choice__trial_starts", 
-        quote({
-            settings[["epoch_choice__trial_starts"]]
-        }), deps = "settings"), input_epoch_choice__trial_ends = targets::tar_target_raw("epoch_choice__trial_ends", 
-        quote({
-            settings[["epoch_choice__trial_ends"]]
-        }), deps = "settings"), input_reference_name = targets::tar_target_raw("reference_name", 
-        quote({
-            settings[["reference_name"]]
-        }), deps = "settings"), input_baseline_settings = targets::tar_target_raw("baseline_settings", 
-        quote({
-            settings[["baseline_settings"]]
-        }), deps = "settings"), input_analysis_electrodes = targets::tar_target_raw("analysis_electrodes", 
-        quote({
-            settings[["analysis_electrodes"]]
-        }), deps = "settings"), input_first_condition_groupings = targets::tar_target_raw("first_condition_groupings", 
-        quote({
-            settings[["first_condition_groupings"]]
-        }), deps = "settings"), input_second_condition_groupings = targets::tar_target_raw("second_condition_groupings", 
-        quote({
-            settings[["second_condition_groupings"]]
-        }), deps = "settings"), input_enable_second_condition_groupings = targets::tar_target_raw("enable_second_condition_groupings", 
-        quote({
-            settings[["enable_second_condition_groupings"]]
-        }), deps = "settings"), input_condition_variable = targets::tar_target_raw("condition_variable", 
-        quote({
-            settings[["condition_variable"]]
-        }), deps = "settings"), input_enable_custom_ROI = targets::tar_target_raw("enable_custom_ROI", 
-        quote({
-            settings[["enable_custom_ROI"]]
-        }), deps = "settings"), input_custom_roi_type = targets::tar_target_raw("custom_roi_type", 
-        quote({
-            settings[["custom_roi_type"]]
-        }), deps = "settings"), input_custom_roi_variable = targets::tar_target_raw("custom_roi_variable", 
-        quote({
-            settings[["custom_roi_variable"]]
-        }), deps = "settings"), input_custom_roi_groupings = targets::tar_target_raw("custom_roi_groupings", 
-        quote({
-            settings[["custom_roi_groupings"]]
-        }), deps = "settings"), input_analysis_settings = targets::tar_target_raw("analysis_settings", 
-        quote({
-            settings[["analysis_settings"]]
+            settings[["electrodes_to_export_roi_categories"]]
         }), deps = "settings"), input_electrodes_to_export_roi_name = targets::tar_target_raw("electrodes_to_export_roi_name", 
         quote({
             settings[["electrodes_to_export_roi_name"]]
-        }), deps = "settings"), input_electrodes_to_export_roi_categories = targets::tar_target_raw("electrodes_to_export_roi_categories", 
+        }), deps = "settings"), input_analysis_settings = targets::tar_target_raw("analysis_settings", 
         quote({
-            settings[["electrodes_to_export_roi_categories"]]
+            settings[["analysis_settings"]]
+        }), deps = "settings"), input_custom_roi_groupings = targets::tar_target_raw("custom_roi_groupings", 
+        quote({
+            settings[["custom_roi_groupings"]]
+        }), deps = "settings"), input_custom_roi_variable = targets::tar_target_raw("custom_roi_variable", 
+        quote({
+            settings[["custom_roi_variable"]]
+        }), deps = "settings"), input_custom_roi_type = targets::tar_target_raw("custom_roi_type", 
+        quote({
+            settings[["custom_roi_type"]]
+        }), deps = "settings"), input_enable_custom_ROI = targets::tar_target_raw("enable_custom_ROI", 
+        quote({
+            settings[["enable_custom_ROI"]]
+        }), deps = "settings"), input_condition_variable = targets::tar_target_raw("condition_variable", 
+        quote({
+            settings[["condition_variable"]]
+        }), deps = "settings"), input_enable_second_condition_groupings = targets::tar_target_raw("enable_second_condition_groupings", 
+        quote({
+            settings[["enable_second_condition_groupings"]]
+        }), deps = "settings"), input_second_condition_groupings = targets::tar_target_raw("second_condition_groupings", 
+        quote({
+            settings[["second_condition_groupings"]]
+        }), deps = "settings"), input_first_condition_groupings = targets::tar_target_raw("first_condition_groupings", 
+        quote({
+            settings[["first_condition_groupings"]]
+        }), deps = "settings"), input_analysis_electrodes = targets::tar_target_raw("analysis_electrodes", 
+        quote({
+            settings[["analysis_electrodes"]]
+        }), deps = "settings"), input_baseline_settings = targets::tar_target_raw("baseline_settings", 
+        quote({
+            settings[["baseline_settings"]]
+        }), deps = "settings"), input_reference_name = targets::tar_target_raw("reference_name", 
+        quote({
+            settings[["reference_name"]]
+        }), deps = "settings"), input_epoch_choice__trial_ends = targets::tar_target_raw("epoch_choice__trial_ends", 
+        quote({
+            settings[["epoch_choice__trial_ends"]]
+        }), deps = "settings"), input_epoch_choice__trial_starts = targets::tar_target_raw("epoch_choice__trial_starts", 
+        quote({
+            settings[["epoch_choice__trial_starts"]]
+        }), deps = "settings"), input_epoch_choice = targets::tar_target_raw("epoch_choice", 
+        quote({
+            settings[["epoch_choice"]]
+        }), deps = "settings"), input_loaded_electrodes = targets::tar_target_raw("loaded_electrodes", 
+        quote({
+            settings[["loaded_electrodes"]]
+        }), deps = "settings"), input_subject_code = targets::tar_target_raw("subject_code", 
+        quote({
+            settings[["subject_code"]]
+        }), deps = "settings"), input_project_name = targets::tar_target_raw("project_name", 
+        quote({
+            settings[["project_name"]]
+        }), deps = "settings"), input_time_censor = targets::tar_target_raw("time_censor", 
+        quote({
+            settings[["time_censor"]]
+        }), deps = "settings"), input_trial_outliers_list = targets::tar_target_raw("trial_outliers_list", 
+        quote({
+            settings[["trial_outliers_list"]]
+        }), deps = "settings"), input_electrode_export_file_type = targets::tar_target_raw("electrode_export_file_type", 
+        quote({
+            settings[["electrode_export_file_type"]]
+        }), deps = "settings"), input_frequencies_to_export = targets::tar_target_raw("frequencies_to_export", 
+        quote({
+            settings[["frequencies_to_export"]]
+        }), deps = "settings"), input_times_to_export = targets::tar_target_raw("times_to_export", 
+        quote({
+            settings[["times_to_export"]]
+        }), deps = "settings"), input_trials_to_export = targets::tar_target_raw("trials_to_export", 
+        quote({
+            settings[["trials_to_export"]]
+        }), deps = "settings"), input_electrodes_to_export = targets::tar_target_raw("electrodes_to_export", 
+        quote({
+            settings[["electrodes_to_export"]]
+        }), deps = "settings"), input_electrode_export_data_type = targets::tar_target_raw("electrode_export_data_type", 
+        quote({
+            settings[["electrode_export_data_type"]]
         }), deps = "settings"), check_load_power = targets::tar_target_raw(name = "repository", 
         command = quote({
             .__target_expr__. <- quote({
@@ -967,6 +967,76 @@ rm(._._env_._.)
                 betfd_success
             }), target_depends = "over_time_by_electrode_data"), 
         deps = "over_time_by_electrode_data", cue = targets::tar_cue("always"), 
+        pattern = NULL, iteration = "list"), build_over_time_by_electrode_and_trial_data = targets::tar_target_raw(name = "over_time_by_electrode_and_trial_data", 
+        command = quote({
+            .__target_expr__. <- quote({
+                build_data <- function(data, analysis_settings, 
+                  condition_group, baseline_settings, ...) {
+                  dm <- dimnames(data)
+                  to_keep <- sapply(c("Time", "Electrode", "Trial"), 
+                    which.equal, names(dm))
+                  res <- list(data = ravetools::collapse(data, 
+                    keep = to_keep), xlab = "Time (s)", ylab = "Electrode #", 
+                    zlab = "Trial", analysis_unit = baseline_settings$unit_of_analysis, 
+                    condition_group = condition_group$label, 
+                    electrodes = as.integer(dm$Electrode))
+                  res[c("x", "y", "z")] <- dimnames(data)[to_keep] %>% 
+                    lapply(as.numeric)
+                  dimnames(res$data) = dimnames(data)[to_keep]
+                  res$N = length(dm$Trial)
+                  if (isTRUE(analysis_settings$censor_info$enabled)) {
+                    ti = res$x %within% analysis_settings$censor_info$window
+                    res$range <- range(res$data[!ti, , ])
+                  } else {
+                    res$range <- range(res$data)
+                  }
+                  return(res)
+                }
+                over_time_by_electrode_and_trial_data <- data_builder(pluriform_power = pluriform_power, 
+                  condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                  build_data)
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(over_time_by_electrode_and_trial_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "over_time_by_electrode_and_trial_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "over_time_by_electrode_and_trial_data", 
+            target_expr = quote({
+                {
+                  build_data <- function(data, analysis_settings, 
+                    condition_group, baseline_settings, ...) {
+                    dm <- dimnames(data)
+                    to_keep <- sapply(c("Time", "Electrode", 
+                      "Trial"), which.equal, names(dm))
+                    res <- list(data = ravetools::collapse(data, 
+                      keep = to_keep), xlab = "Time (s)", ylab = "Electrode #", 
+                      zlab = "Trial", analysis_unit = baseline_settings$unit_of_analysis, 
+                      condition_group = condition_group$label, 
+                      electrodes = as.integer(dm$Electrode))
+                    res[c("x", "y", "z")] <- dimnames(data)[to_keep] %>% 
+                      lapply(as.numeric)
+                    dimnames(res$data) = dimnames(data)[to_keep]
+                    res$N = length(dm$Trial)
+                    if (isTRUE(analysis_settings$censor_info$enabled)) {
+                      ti = res$x %within% analysis_settings$censor_info$window
+                      res$range <- range(res$data[!ti, , ])
+                    } else {
+                      res$range <- range(res$data)
+                    }
+                    return(res)
+                  }
+                  over_time_by_electrode_and_trial_data <- data_builder(pluriform_power = pluriform_power, 
+                    condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                    build_data)
+                }
+                over_time_by_electrode_and_trial_data
+            }), target_depends = c("pluriform_power", "analysis_groups", 
+            "baseline_settings")), deps = c("pluriform_power", 
+        "analysis_groups", "baseline_settings"), cue = targets::tar_cue("thorough"), 
         pattern = NULL, iteration = "list"), build_over_time_by_condition_data = targets::tar_target_raw(name = "over_time_by_condition_data", 
         command = quote({
             .__target_expr__. <- quote({
@@ -2294,4 +2364,42 @@ rm(._._env_._.)
         "analysis_groups", "trial_outliers_list", "condition_variable", 
         "times_to_export", "frequencies_to_export", "electrode_export_data_type"
         ), cue = targets::tar_cue("always"), pattern = NULL, 
+        iteration = "list"), build_data_for_group_analysis = targets::tar_target_raw(name = "data_for_group_analysis", 
+        command = quote({
+            .__target_expr__. <- quote({
+                data_for_group_analysis <- list()
+                data_for_group_analysis$baseline_settings <- baseline_settings
+                data_for_group_analysis$analysis_settings_clean <- analysis_settings_clean
+                data_for_group_analysis$electrode_information <- subset(repository$electrode_table, 
+                  repository$electrode_table$Electrode %in% repository$electrode_list)
+                data_for_group_analysis$over_time_by_electrode_data <- over_time_by_electrode_data
+                data_for_group_analysis$omnibus_stats <- omnibus_results$stats
+                data_for_group_analysis$omnibus_data <- omnibus_results$data_with_outliers
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(data_for_group_analysis)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "data_for_group_analysis", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "data_for_group_analysis", target_expr = quote({
+                {
+                  data_for_group_analysis <- list()
+                  data_for_group_analysis$baseline_settings <- baseline_settings
+                  data_for_group_analysis$analysis_settings_clean <- analysis_settings_clean
+                  data_for_group_analysis$electrode_information <- subset(repository$electrode_table, 
+                    repository$electrode_table$Electrode %in% 
+                      repository$electrode_list)
+                  data_for_group_analysis$over_time_by_electrode_data <- over_time_by_electrode_data
+                  data_for_group_analysis$omnibus_stats <- omnibus_results$stats
+                  data_for_group_analysis$omnibus_data <- omnibus_results$data_with_outliers
+                }
+                data_for_group_analysis
+            }), target_depends = c("baseline_settings", "analysis_settings_clean", 
+            "repository", "over_time_by_electrode_data", "omnibus_results"
+            )), deps = c("baseline_settings", "analysis_settings_clean", 
+        "repository", "over_time_by_electrode_data", "omnibus_results"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
         iteration = "list"))

--- a/modules/power_explorer/make-power_explorer.R
+++ b/modules/power_explorer/make-power_explorer.R
@@ -15,84 +15,162 @@ rm(._._env_._.)
 ...targets <- list(`__Check_settings_file` = targets::tar_target_raw("settings_path", 
     "settings.yaml", format = "file"), `__Load_settings` = targets::tar_target_raw("settings", 
     quote({
-        load_yaml(settings_path)
-    }), deps = "settings_path", cue = targets::tar_cue("always")),
-    input_analysis_settings = targets::tar_target_raw("analysis_settings",
+        yaml::read_yaml(settings_path)
+    }), deps = "settings_path", cue = targets::tar_cue("always")), 
+    input_electrode_export_data_type = targets::tar_target_raw("electrode_export_data_type", 
         quote({
-            settings[["analysis_settings"]]
-        }), deps = "settings"), input_reference_name = targets::tar_target_raw("reference_name",
+            settings[["electrode_export_data_type"]]
+        }), deps = "settings"), input_electrodes_to_export = targets::tar_target_raw("electrodes_to_export", 
         quote({
-            settings[["reference_name"]]
-        }), deps = "settings"), input_baseline_settings = targets::tar_target_raw("baseline_settings",
+            settings[["electrodes_to_export"]]
+        }), deps = "settings"), input_trials_to_export = targets::tar_target_raw("trials_to_export", 
         quote({
-            settings[["baseline_settings"]]
-        }), deps = "settings"), input_electrodes_list = targets::tar_target_raw("electrodes_list",
+            settings[["trials_to_export"]]
+        }), deps = "settings"), input_times_to_export = targets::tar_target_raw("times_to_export", 
         quote({
-            settings[["electrodes_list"]]
-        }), deps = "settings"), input_project_name = targets::tar_target_raw("project_name",
+            settings[["times_to_export"]]
+        }), deps = "settings"), input_frequencies_to_export = targets::tar_target_raw("frequencies_to_export", 
         quote({
-            settings[["project_name"]]
-        }), deps = "settings"), input_first_condition_groupings = targets::tar_target_raw("first_condition_groupings",
+            settings[["frequencies_to_export"]]
+        }), deps = "settings"), input_electrode_export_file_type = targets::tar_target_raw("electrode_export_file_type", 
         quote({
-            settings[["first_condition_groupings"]]
-        }), deps = "settings"), input_analysis_electrodes__category = targets::tar_target_raw("analysis_electrodes__category",
-        quote({
-            settings[["analysis_electrodes__category"]]
-        }), deps = "settings"), input_selected_electrodes = targets::tar_target_raw("selected_electrodes",
-        quote({
-            settings[["selected_electrodes"]]
-        }), deps = "settings"), input_epoch_choice = targets::tar_target_raw("epoch_choice",
-        quote({
-            settings[["epoch_choice"]]
-        }), deps = "settings"), input_time_censor = targets::tar_target_raw("time_censor",
-        quote({
-            settings[["time_censor"]]
-        }), deps = "settings"), input_subject_name = targets::tar_target_raw("subject_name",
-        quote({
-            settings[["subject_name"]]
-        }), deps = "settings"), input_tensor_collapse_method = targets::tar_target_raw("tensor_collapse_method",
-        quote({
-            settings[["tensor_collapse_method"]]
-        }), deps = "settings"), input_electrode_groupings = targets::tar_target_raw("electrode_groupings",
-        quote({
-            settings[["electrode_groupings"]]
-        }), deps = "settings"), input_trial_outliers_list = targets::tar_target_raw("trial_outliers_list",
+            settings[["electrode_export_file_type"]]
+        }), deps = "settings"), input_trial_outliers_list = targets::tar_target_raw("trial_outliers_list", 
         quote({
             settings[["trial_outliers_list"]]
-        }), deps = "settings"), input_epoch_choice__trial_ends = targets::tar_target_raw("epoch_choice__trial_ends",
+        }), deps = "settings"), input_time_censor = targets::tar_target_raw("time_censor", 
         quote({
-            settings[["epoch_choice__trial_ends"]]
-        }), deps = "settings"), input_epoch_choice__trial_starts = targets::tar_target_raw("epoch_choice__trial_starts",
+            settings[["time_censor"]]
+        }), deps = "settings"), input_project_name = targets::tar_target_raw("project_name", 
+        quote({
+            settings[["project_name"]]
+        }), deps = "settings"), input_subject_code = targets::tar_target_raw("subject_code", 
+        quote({
+            settings[["subject_code"]]
+        }), deps = "settings"), input_loaded_electrodes = targets::tar_target_raw("loaded_electrodes", 
+        quote({
+            settings[["loaded_electrodes"]]
+        }), deps = "settings"), input_epoch_choice = targets::tar_target_raw("epoch_choice", 
+        quote({
+            settings[["epoch_choice"]]
+        }), deps = "settings"), input_epoch_choice__trial_starts = targets::tar_target_raw("epoch_choice__trial_starts", 
         quote({
             settings[["epoch_choice__trial_starts"]]
-        }), deps = "settings"), check_load_power = targets::tar_target_raw(name = "repository",
+        }), deps = "settings"), input_epoch_choice__trial_ends = targets::tar_target_raw("epoch_choice__trial_ends", 
+        quote({
+            settings[["epoch_choice__trial_ends"]]
+        }), deps = "settings"), input_reference_name = targets::tar_target_raw("reference_name", 
+        quote({
+            settings[["reference_name"]]
+        }), deps = "settings"), input_baseline_settings = targets::tar_target_raw("baseline_settings", 
+        quote({
+            settings[["baseline_settings"]]
+        }), deps = "settings"), input_analysis_electrodes = targets::tar_target_raw("analysis_electrodes", 
+        quote({
+            settings[["analysis_electrodes"]]
+        }), deps = "settings"), input_first_condition_groupings = targets::tar_target_raw("first_condition_groupings", 
+        quote({
+            settings[["first_condition_groupings"]]
+        }), deps = "settings"), input_second_condition_groupings = targets::tar_target_raw("second_condition_groupings", 
+        quote({
+            settings[["second_condition_groupings"]]
+        }), deps = "settings"), input_enable_second_condition_groupings = targets::tar_target_raw("enable_second_condition_groupings", 
+        quote({
+            settings[["enable_second_condition_groupings"]]
+        }), deps = "settings"), input_condition_variable = targets::tar_target_raw("condition_variable", 
+        quote({
+            settings[["condition_variable"]]
+        }), deps = "settings"), input_enable_custom_ROI = targets::tar_target_raw("enable_custom_ROI", 
+        quote({
+            settings[["enable_custom_ROI"]]
+        }), deps = "settings"), input_custom_roi_type = targets::tar_target_raw("custom_roi_type", 
+        quote({
+            settings[["custom_roi_type"]]
+        }), deps = "settings"), input_custom_roi_variable = targets::tar_target_raw("custom_roi_variable", 
+        quote({
+            settings[["custom_roi_variable"]]
+        }), deps = "settings"), input_custom_roi_groupings = targets::tar_target_raw("custom_roi_groupings", 
+        quote({
+            settings[["custom_roi_groupings"]]
+        }), deps = "settings"), input_analysis_settings = targets::tar_target_raw("analysis_settings", 
+        quote({
+            settings[["analysis_settings"]]
+        }), deps = "settings"), input_electrodes_to_export_roi_name = targets::tar_target_raw("electrodes_to_export_roi_name", 
+        quote({
+            settings[["electrodes_to_export_roi_name"]]
+        }), deps = "settings"), input_electrodes_to_export_roi_categories = targets::tar_target_raw("electrodes_to_export_roi_categories", 
+        quote({
+            settings[["electrodes_to_export_roi_categories"]]
+        }), deps = "settings"), check_load_power = targets::tar_target_raw(name = "repository", 
         command = quote({
-            {
-                proj_subj <- sprintf("%s/%s", project_name, subject_name)
-                repository <- raveio::prepare_subject_power(subject = proj_subj,
-                  electrodes = electrodes_list, epoch_name = epoch_choice,
-                  reference_name = reference_name, time_windows = c(epoch_choice__trial_starts,
+            .__target_expr__. <- quote({
+                subject <- raveio::as_rave_subject(subject_id = sprintf("%s/%s", 
+                  project_name, subject_code))
+                repository <- raveio::prepare_subject_power(subject = subject, 
+                  electrodes = loaded_electrodes, epoch_name = epoch_choice, 
+                  reference_name = reference_name, time_windows = c(epoch_choice__trial_starts, 
                     epoch_choice__trial_ends))
                 repository
-            }
-            return(repository)
-        }), deps = c("project_name", "subject_name", "electrodes_list",
-        "epoch_choice", "reference_name", "epoch_choice__trial_starts",
-        "epoch_choice__trial_ends"), cue = targets::tar_cue("always"),
-        pattern = NULL, iteration = "list"), check_requested_electrodes = targets::tar_target_raw(name = "requested_electrodes",
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(repository)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "repository", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = "rave_prepare_power", 
+            target_export = "repository", target_expr = quote({
+                {
+                  subject <- raveio::as_rave_subject(subject_id = sprintf("%s/%s", 
+                    project_name, subject_code))
+                  repository <- raveio::prepare_subject_power(subject = subject, 
+                    electrodes = loaded_electrodes, epoch_name = epoch_choice, 
+                    reference_name = reference_name, time_windows = c(epoch_choice__trial_starts, 
+                      epoch_choice__trial_ends))
+                  repository
+                }
+                repository
+            }), target_depends = c("project_name", "subject_code", 
+            "loaded_electrodes", "epoch_choice", "reference_name", 
+            "epoch_choice__trial_starts", "epoch_choice__trial_ends"
+            )), deps = c("project_name", "subject_code", "loaded_electrodes", 
+        "epoch_choice", "reference_name", "epoch_choice__trial_starts", 
+        "epoch_choice__trial_ends"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), check_requested_electrodes = targets::tar_target_raw(name = "requested_electrodes", 
         command = quote({
-            {
-                requested_electrodes <- dipsaus::parse_svec(selected_electrodes,
+            .__target_expr__. <- quote({
+                requested_electrodes <- dipsaus::parse_svec(analysis_electrodes, 
                   sep = ",|;", connect = ":-")
-                requested_electrodes <- requested_electrodes[requested_electrodes %in%
+                requested_electrodes <- requested_electrodes[requested_electrodes %in% 
                   repository$power$dimnames$Electrode]
                 if (!length(requested_electrodes)) {
                   stop("No electrode selected")
                 }
-            }
-            return(requested_electrodes)
-        }), deps = c("selected_electrodes", "repository"), cue = targets::tar_cue("thorough"),
-        pattern = NULL, iteration = "list"), check_analysis_settings = targets::tar_target_raw(name = "analysis_checks_passed",
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(requested_electrodes)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "requested_electrodes", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "requested_electrodes", target_expr = quote({
+                {
+                  requested_electrodes <- dipsaus::parse_svec(analysis_electrodes, 
+                    sep = ",|;", connect = ":-")
+                  requested_electrodes <- requested_electrodes[requested_electrodes %in% 
+                    repository$power$dimnames$Electrode]
+                  if (!length(requested_electrodes)) {
+                    stop("No electrode selected")
+                  }
+                }
+                requested_electrodes
+            }), target_depends = c("analysis_electrodes", "repository"
+            )), deps = c("analysis_electrodes", "repository"), 
+        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"), 
+    check_analysis_settings = targets::tar_target_raw(name = "analysis_settings_clean", 
         command = quote({
             .__target_expr__. <- quote({
                 check_range <- function(x, lim, lbl) {
@@ -101,19 +179,20 @@ rm(._._env_._.)
                       ":")), call. = FALSE)
                 }
                 if (length(repository$time_windows) != 1) stop("discontinuous time windows not supported")
-                analysis_settings %<>% lapply(function(as) {
-                  as$time %<>% unlist
-                  as$frequency %<>% unlist
-                  if (is.null(as$label) || nchar(as$label) <
-                    1) {
-                    as$label <- paste("Window", stri_rand_strings(1,
-                      4))
-                  }
-                  if (is.null(as$censor_info)) {
-                    as$censor_info <- list(enabled = FALSE, window = 0:1)
-                  }
-                  return(as)
-                })
+                analysis_settings_clean <- lapply(analysis_settings, 
+                  function(as) {
+                    as$time %<>% unlist
+                    as$frequency %<>% unlist
+                    if (is.null(as$label) || nchar(as$label) < 
+                      1) {
+                      as$label <- paste("Window", rand_string(length = 4))
+                    }
+                    if (is.null(as$censor_info)) {
+                      as$censor_info <- list(enabled = FALSE, 
+                        window = 0:1)
+                    }
+                    return(as)
+                  })
                 ua <- get_unit_of_analysis(names = TRUE)
                 if (!baseline_settings$unit_of_analysis %in% 
                   ua) {
@@ -125,134 +204,464 @@ rm(._._env_._.)
                   stop(sprintf("Requested baseline scope \"%s\" must be one of: %s", 
                     baseline_settings$scope, str_collapse(ua)))
                 }
-                sapply(analysis_settings, function(setting) {
-                  check_range(setting$frequency, unlist(repository$frequency),
+                lapply(analysis_settings_clean, function(setting) {
+                  check_range(setting$frequency, unlist(repository$frequency), 
                     "frequency")
                   check_range(setting$time, unlist(repository$time_windows), 
                     "analysis time")
                 })
-                names(analysis_settings) <- sapply(analysis_settings,
+                names(analysis_settings_clean) <- sapply(analysis_settings_clean, 
                   `[[`, "label")
-                dd <- duplicated(sapply(analysis_settings, `[[`,
-                  "label"))
-                while (sum(dd)) {
-                  for (w in which(dd)) {
-                    analysis_settings[[w]]$label = paste(analysis_settings[[w]]$label,
-                      stringi::stri_rand_strings(n = 1, length = 4))
-                  }
-                  dd <- duplicated(sapply(analysis_settings,
-                    `[[`, "label"))
-                }
-                for (ii in seq_along(analysis_settings)) {
-                  analysis_settings[[ii]]$censor_info = time_censor
-                  analysis_settings[[ii]]$censor_info$window %<>%
-                    unlist
-                }
-                for (ii in seq_along(first_condition_groupings)) {
-                  if (nchar(first_condition_groupings[[ii]]$label) <
-                    1) {
-                    first_condition_groupings[[ii]]$label = paste("Group",
-                      ii)
-                  }
-                }
-                dd <- duplicated(sapply(first_condition_groupings,
+                dd <- duplicated(sapply(analysis_settings_clean, 
                   `[[`, "label"))
                 while (sum(dd)) {
                   for (w in which(dd)) {
-                    first_condition_groupings[[w]]$label = paste(first_condition_groupings[[w]]$label,
-                      stringi::stri_rand_strings(n = 1, length = 4))
+                    analysis_settings_clean[[w]]$label = paste(analysis_settings_clean[[w]]$label, 
+                      rand_string(length = 4))
                   }
-                  dd <- duplicated(sapply(first_condition_groupings,
+                  dd <- duplicated(sapply(analysis_settings_clean, 
                     `[[`, "label"))
+                }
+                for (ii in seq_along(analysis_settings_clean)) {
+                  analysis_settings_clean[[ii]]$censor_info = time_censor
+                  analysis_settings_clean[[ii]]$censor_info$window %<>% 
+                    unlist
+                }
+                for (ii in seq_along(first_condition_groupings)) {
+                  if (!nzchar(first_condition_groupings[[ii]]$label)) {
+                    first_condition_groupings[[ii]]$label = paste("Group", 
+                      ii)
+                  }
+                }
+                dd <- duplicated(sapply(first_condition_groupings, 
+                  `[[`, "label"))
+                while (sum(dd)) {
+                  for (w in which(dd)) {
+                    first_condition_groupings[[w]]$label = paste(first_condition_groupings[[w]]$label, 
+                      rand_string(length = 4))
+                  }
+                  dd <- duplicated(sapply(first_condition_groupings, 
+                    `[[`, "label"))
+                }
+                fcg <- c(unlist(sapply(first_condition_groupings, 
+                  `[[`, "conditions")))
+                if (isTRUE(enable_second_condition_groupings)) {
+                  scg <- c(unlist(sapply(second_condition_groupings, 
+                    `[[`, "conditions")))
+                  stopifnot(setequal(scg, fcg))
+                  stopifnot(all(!duplicated(scg)))
+                }
+                if (any(duplicated(fcg))) {
+                  warning("Duplication in first factor, results may be unreliable")
                 }
                 if (is.list(trial_outliers_list)) {
                   trial_outliers_list %<>% unlist
                 }
+                for (ii in seq_along(analysis_settings_clean)) {
+                  analysis_settings_clean[[ii]]$subject_code = subject_code
+                  analysis_settings_clean[[ii]]$project_name = project_name
+                }
                 analysis_checks_passed = TRUE
-            }
-            return(analysis_checks_passed)
-        }), deps = c("repository", "analysis_settings", "baseline_settings",
-        "time_censor", "first_condition_groupings", "trial_outliers_list"
-        ), cue = targets::tar_cue("thorough"), pattern = NULL,
-        iteration = "list"), calculate_baseline = targets::tar_target_raw(name = "baselined_power",
-        command = quote({
-            {
-                stopifnot(analysis_checks_passed)
-                raveio::with_future_parallel({
-                  raveio::power_baseline(x = repository, baseline_windows = unlist(baseline_settings$window[[1]]),
-                    method = get_unit_of_analysis(baseline_settings$unit_of_analysis),
-                    units = get_baseline_scope(baseline_settings$scope),
-                    signal_type = "LFP", electrodes = requested_electrodes)
-                })
-                baselined_power <- subset(repository$power$baselined,
-                  Electrode ~ Electrode %in% requested_electrodes)
-            }
-            return(baselined_power)
-        }), deps = c("analysis_checks_passed", "repository",
-        "baseline_settings", "requested_electrodes"), cue = targets::tar_cue("always"),
-        pattern = NULL, iteration = "list"), build_trial_groupings = targets::tar_target_raw(name = "analysis_groups",
-        command = quote({
-            {
-                analysis_groups <- mapply(function(cg, ii) {
-                  trials <- c()
-                  if (length(cg$conditions) > 0) {
-                    trials <- repository$epoch$table$Trial[repository$epoch$table$Condition %in%
-                      cg$conditions]
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(analysis_settings_clean)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "analysis_settings_clean", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "analysis_settings_clean", target_expr = quote({
+                {
+                  check_range <- function(x, lim, lbl) {
+                    if (!all(x %within% lim)) stop(sprintf("Requested %s [%s] not within available range [%s]", 
+                      lbl, str_collapse(range(x), ":"), str_collapse(range(lim), 
+                        ":")), call. = FALSE)
                   }
-                  list(label = cg$label, conditions = cg$conditions,
-                    trials = trials, index = ii, has_trials = length(trials) >
-                      0, electrodes = requested_electrodes)
-                }, first_condition_groupings, seq_along(first_condition_groupings),
-                  SIMPLIFY = FALSE)
-                names(analysis_groups) <- sapply(analysis_groups,
-                  `[[`, "label")
-                if (!any(vapply(analysis_groups, `[[`, FALSE,
-                  "has_trials"))) stop("No trials available in condition groups")
-            }
-            return(analysis_groups)
-        }), deps = c("repository", "requested_electrodes", "first_condition_groupings"
-        ), cue = targets::tar_cue("thorough"), pattern = NULL,
-        iteration = "list"), build_pluriform_power = targets::tar_target_raw(name = "pluriform_power",
+                  if (length(repository$time_windows) != 1) stop("discontinuous time windows not supported")
+                  analysis_settings_clean <- lapply(analysis_settings, 
+                    function(as) {
+                      as$time %<>% unlist
+                      as$frequency %<>% unlist
+                      if (is.null(as$label) || nchar(as$label) < 
+                        1) {
+                        as$label <- paste("Window", rand_string(length = 4))
+                      }
+                      if (is.null(as$censor_info)) {
+                        as$censor_info <- list(enabled = FALSE, 
+                          window = 0:1)
+                      }
+                      return(as)
+                    })
+                  ua <- get_unit_of_analysis(names = TRUE)
+                  if (!baseline_settings$unit_of_analysis %in% 
+                    ua) {
+                    stop(sprintf("Requested unit of analysis \"%s\" must be one of: %s", 
+                      baseline_settings$unit_of_analysis, str_collapse(ua)))
+                  }
+                  ua <- get_baseline_scope(names = TRUE)
+                  if (!baseline_settings$scope %in% ua) {
+                    stop(sprintf("Requested baseline scope \"%s\" must be one of: %s", 
+                      baseline_settings$scope, str_collapse(ua)))
+                  }
+                  lapply(analysis_settings_clean, function(setting) {
+                    check_range(setting$frequency, unlist(repository$frequency), 
+                      "frequency")
+                    check_range(setting$time, unlist(repository$time_windows), 
+                      "analysis time")
+                  })
+                  names(analysis_settings_clean) <- sapply(analysis_settings_clean, 
+                    `[[`, "label")
+                  dd <- duplicated(sapply(analysis_settings_clean, 
+                    `[[`, "label"))
+                  while (sum(dd)) {
+                    for (w in which(dd)) {
+                      analysis_settings_clean[[w]]$label = paste(analysis_settings_clean[[w]]$label, 
+                        rand_string(length = 4))
+                    }
+                    dd <- duplicated(sapply(analysis_settings_clean, 
+                      `[[`, "label"))
+                  }
+                  for (ii in seq_along(analysis_settings_clean)) {
+                    analysis_settings_clean[[ii]]$censor_info = time_censor
+                    analysis_settings_clean[[ii]]$censor_info$window %<>% 
+                      unlist
+                  }
+                  for (ii in seq_along(first_condition_groupings)) {
+                    if (!nzchar(first_condition_groupings[[ii]]$label)) {
+                      first_condition_groupings[[ii]]$label = paste("Group", 
+                        ii)
+                    }
+                  }
+                  dd <- duplicated(sapply(first_condition_groupings, 
+                    `[[`, "label"))
+                  while (sum(dd)) {
+                    for (w in which(dd)) {
+                      first_condition_groupings[[w]]$label = paste(first_condition_groupings[[w]]$label, 
+                        rand_string(length = 4))
+                    }
+                    dd <- duplicated(sapply(first_condition_groupings, 
+                      `[[`, "label"))
+                  }
+                  fcg <- c(unlist(sapply(first_condition_groupings, 
+                    `[[`, "conditions")))
+                  if (isTRUE(enable_second_condition_groupings)) {
+                    scg <- c(unlist(sapply(second_condition_groupings, 
+                      `[[`, "conditions")))
+                    stopifnot(setequal(scg, fcg))
+                    stopifnot(all(!duplicated(scg)))
+                  }
+                  if (any(duplicated(fcg))) {
+                    warning("Duplication in first factor, results may be unreliable")
+                  }
+                  if (is.list(trial_outliers_list)) {
+                    trial_outliers_list %<>% unlist
+                  }
+                  for (ii in seq_along(analysis_settings_clean)) {
+                    analysis_settings_clean[[ii]]$subject_code = subject_code
+                    analysis_settings_clean[[ii]]$project_name = project_name
+                  }
+                  analysis_checks_passed = TRUE
+                }
+                analysis_settings_clean
+            }), target_depends = c("repository", "analysis_settings", 
+            "baseline_settings", "time_censor", "first_condition_groupings", 
+            "enable_second_condition_groupings", "second_condition_groupings", 
+            "trial_outliers_list", "subject_code", "project_name"
+            )), deps = c("repository", "analysis_settings", "baseline_settings", 
+        "time_censor", "first_condition_groupings", "enable_second_condition_groupings", 
+        "second_condition_groupings", "trial_outliers_list", 
+        "subject_code", "project_name"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), calculate_baseline = targets::tar_target_raw(name = "baselined_power", 
         command = quote({
-            {
+            .__target_expr__. <- quote({
+                raveio::power_baseline(x = repository, baseline_windows = baseline_settings$window, 
+                  method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                  units = get_baseline_scope(baseline_settings$scope), 
+                  signal_type = "LFP", electrodes = requested_electrodes)
+                baselined_power <- repository$power$baselined
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(baselined_power)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "baselined_power", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = "user-defined-r", 
+            target_export = "baselined_power", target_expr = quote({
+                {
+                  raveio::power_baseline(x = repository, baseline_windows = baseline_settings$window, 
+                    method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                    units = get_baseline_scope(baseline_settings$scope), 
+                    signal_type = "LFP", electrodes = requested_electrodes)
+                  baselined_power <- repository$power$baselined
+                }
+                baselined_power
+            }), target_depends = c("repository", "baseline_settings", 
+            "requested_electrodes")), deps = c("repository", 
+        "baseline_settings", "requested_electrodes"), cue = targets::tar_cue("always"), 
+        pattern = NULL, iteration = "list"), build_trial_details = targets::tar_target_raw(name = "trial_details", 
+        command = quote({
+            .__target_expr__. <- quote({
+                k = sapply(lapply(first_condition_groupings, 
+                  `[[`, "conditions"), length)
+                fcgs <- first_condition_groupings[k > 0]
+                all_trials <- c(unname(unlist(lapply(fcgs, `[[`, 
+                  "conditions"))))
+                ep_table <- repository$epoch$table
+                tbl <- subset(ep_table, ep_table[[condition_variable]] %in% 
+                  all_trials, select = c("Trial", condition_variable))
+                f1 <- rutabaga::rbind_list(lapply(fcgs, function(ff) {
+                  df = list()
+                  df[[condition_variable]] = ff$conditions
+                  df$Factor1 = ff$label
+                  as.data.frame(df)
+                }))
+                trial_details <- merge(tbl, f1, by = condition_variable)
+                if (isTRUE(enable_second_condition_groupings)) {
+                  f2 <- rutabaga::rbind_list(lapply(second_condition_groupings, 
+                    function(ff) {
+                      df = list()
+                      df[[condition_variable]] = ff$conditions
+                      df$Factor2 = ff$label
+                      as.data.frame(df)
+                    }))
+                  trial_details %<>% merge(f2, by = condition_variable)
+                }
+                trial_details = trial_details[order(trial_details$Trial), 
+                  ]
+                trial_details$Factor1 %<>% factor(levels = sapply(fcgs, 
+                  `[[`, "label"))
+                if (!is.null(trial_details$Factor2)) {
+                  trial_details$Factor2 %<>% factor(levels = sapply(second_condition_groupings, 
+                    `[[`, "label"))
+                }
+                rownames(trial_details) = trial_details$Trial
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(trial_details)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "trial_details", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "trial_details", target_expr = quote({
+                {
+                  k = sapply(lapply(first_condition_groupings, 
+                    `[[`, "conditions"), length)
+                  fcgs <- first_condition_groupings[k > 0]
+                  all_trials <- c(unname(unlist(lapply(fcgs, 
+                    `[[`, "conditions"))))
+                  ep_table <- repository$epoch$table
+                  tbl <- subset(ep_table, ep_table[[condition_variable]] %in% 
+                    all_trials, select = c("Trial", condition_variable))
+                  f1 <- rutabaga::rbind_list(lapply(fcgs, function(ff) {
+                    df = list()
+                    df[[condition_variable]] = ff$conditions
+                    df$Factor1 = ff$label
+                    as.data.frame(df)
+                  }))
+                  trial_details <- merge(tbl, f1, by = condition_variable)
+                  if (isTRUE(enable_second_condition_groupings)) {
+                    f2 <- rutabaga::rbind_list(lapply(second_condition_groupings, 
+                      function(ff) {
+                        df = list()
+                        df[[condition_variable]] = ff$conditions
+                        df$Factor2 = ff$label
+                        as.data.frame(df)
+                      }))
+                    trial_details %<>% merge(f2, by = condition_variable)
+                  }
+                  trial_details = trial_details[order(trial_details$Trial), 
+                    ]
+                  trial_details$Factor1 %<>% factor(levels = sapply(fcgs, 
+                    `[[`, "label"))
+                  if (!is.null(trial_details$Factor2)) {
+                    trial_details$Factor2 %<>% factor(levels = sapply(second_condition_groupings, 
+                      `[[`, "label"))
+                  }
+                  rownames(trial_details) = trial_details$Trial
+                }
+                trial_details
+            }), target_depends = c("first_condition_groupings", 
+            "repository", "condition_variable", "enable_second_condition_groupings", 
+            "second_condition_groupings")), deps = c("first_condition_groupings", 
+        "repository", "condition_variable", "enable_second_condition_groupings", 
+        "second_condition_groupings"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), build_analysis_groups = targets::tar_target_raw(name = "analysis_groups", 
+        command = quote({
+            .__target_expr__. <- quote({
+                if (isTRUE(enable_second_condition_groupings)) {
+                  by_group <- split(trial_details, list(trial_details$Factor1, 
+                    trial_details$Factor2))
+                  analysis_groups <- vector("list", length(by_group))
+                  for (ii in seq_along(by_group)) {
+                    analysis_groups[[ii]] <- list(label = names(by_group)[[ii]], 
+                      conditions = unique(by_group[[ii]]$Condition), 
+                      condition_per_trial = by_group[[ii]]$Condition, 
+                      trials = by_group[[ii]]$Trial, index = ii, 
+                      has_trials = TRUE)
+                  }
+                  attr(analysis_groups, "meta") <- trial_details
+                } else {
+                  analysis_groups <- mapply(function(cg, ii) {
+                    trials <- c()
+                    if (length(cg$conditions) > 0) {
+                      trials <- repository$epoch$table$Trial[repository$epoch$table[[condition_variable]] %in% 
+                        cg$conditions]
+                    }
+                    list(label = cg$label, conditions = cg$conditions, 
+                      trials = trials, index = ii, has_trials = length(trials) > 
+                        0)
+                  }, first_condition_groupings, seq_along(first_condition_groupings), 
+                    SIMPLIFY = FALSE)
+                  has_trials <- which(sapply(analysis_groups, 
+                    `[[`, "has_trials"))
+                  analysis_groups = analysis_groups[has_trials]
+                }
+                if (length(analysis_groups) < 1) stop("No trials available in condition groups")
+                names(analysis_groups) <- sapply(analysis_groups, 
+                  `[[`, "label")
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(analysis_groups)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "analysis_groups", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "analysis_groups", target_expr = quote({
+                {
+                  if (isTRUE(enable_second_condition_groupings)) {
+                    by_group <- split(trial_details, list(trial_details$Factor1, 
+                      trial_details$Factor2))
+                    analysis_groups <- vector("list", length(by_group))
+                    for (ii in seq_along(by_group)) {
+                      analysis_groups[[ii]] <- list(label = names(by_group)[[ii]], 
+                        conditions = unique(by_group[[ii]]$Condition), 
+                        condition_per_trial = by_group[[ii]]$Condition, 
+                        trials = by_group[[ii]]$Trial, index = ii, 
+                        has_trials = TRUE)
+                    }
+                    attr(analysis_groups, "meta") <- trial_details
+                  } else {
+                    analysis_groups <- mapply(function(cg, ii) {
+                      trials <- c()
+                      if (length(cg$conditions) > 0) {
+                        trials <- repository$epoch$table$Trial[repository$epoch$table[[condition_variable]] %in% 
+                          cg$conditions]
+                      }
+                      list(label = cg$label, conditions = cg$conditions, 
+                        trials = trials, index = ii, has_trials = length(trials) > 
+                          0)
+                    }, first_condition_groupings, seq_along(first_condition_groupings), 
+                      SIMPLIFY = FALSE)
+                    has_trials <- which(sapply(analysis_groups, 
+                      `[[`, "has_trials"))
+                    analysis_groups = analysis_groups[has_trials]
+                  }
+                  if (length(analysis_groups) < 1) stop("No trials available in condition groups")
+                  names(analysis_groups) <- sapply(analysis_groups, 
+                    `[[`, "label")
+                }
+                analysis_groups
+            }), target_depends = c("enable_second_condition_groupings", 
+            "trial_details", "repository", "condition_variable", 
+            "first_condition_groupings")), deps = c("enable_second_condition_groupings", 
+        "trial_details", "repository", "condition_variable", 
+        "first_condition_groupings"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), build_pluriform_power = targets::tar_target_raw(name = "pluriform_power", 
+        command = quote({
+            .__target_expr__. <- quote({
+                options(future.globals.maxSize = 12 * 1024^3)
                 epoch_event_types = get_available_events(repository$epoch$columns)
-                pluriform_power <- sapply(analysis_groups, function(ag) {
-                  sapply(analysis_settings, function(as) {
-                    p <- get_pluriform_power(baselined_data = baselined_power,
-                      trial_indices = ag$trials, events = repository$epoch$table,
-                      epoch_event_types = epoch_event_types,
-                      trial_outliers_list = unlist(trial_outliers_list),
-                      event_of_interest = as$event, )
-                    list(data = p, settings = as)
-                  }, simplify = FALSE, USE.NAMES = TRUE)
-                }, simplify = FALSE, USE.NAMES = TRUE)
+                baselined_power_data <- subset(baselined_power, 
+                  Electrode ~ Electrode %in% requested_electrodes)
+                pluriform_power <- raveio::lapply_async(analysis_groups, 
+                  callback = function(x) {
+                    paste("[build_pluriform_power] working on:", 
+                      x$label, "data")
+                  }, FUN = function(ag) {
+                    sapply(analysis_settings_clean, function(as) {
+                      p <- get_pluriform_power(baselined_data = baselined_power_data, 
+                        trial_indices = ag$trials, events = repository$epoch$table, 
+                        epoch_event_types = epoch_event_types, 
+                        trial_outliers_list = unlist(trial_outliers_list), 
+                        event_of_interest = as$event, sample_rate = repository$subject$power_sample_rate)
+                      list(data = p, settings = as, outliers = trial_outliers_list)
+                    }, simplify = FALSE, USE.NAMES = TRUE)
+                  })
                 for (gg in seq_along(pluriform_power)) {
                   for (aa in seq_along(pluriform_power[[gg]])) {
-                    fi <- as.numeric(dimnames(pluriform_power[[gg]][[aa]]$data$shifted_data)$Frequency) %within%
+                    fi <- as.numeric(dimnames(pluriform_power[[gg]][[aa]]$data$shifted_data)$Frequency) %within% 
                       unlist(pluriform_power[[gg]][[aa]]$settings$frequency)
-                    pluriform_power[[gg]][[aa]]$data$shifted_data_Fsub <- pluriform_power[[gg]][[aa]]$data$shifted_data[fi,
+                    pluriform_power[[gg]][[aa]]$data$shifted_data_Fsub <- pluriform_power[[gg]][[aa]]$data$shifted_data[fi, 
                       , , , drop = FALSE]
-                    pluriform_power[[gg]][[aa]]$data$shifted_clean_data_Fsub = pluriform_power[[gg]][[aa]]$data$shifted_clean_data[fi,
+                    pluriform_power[[gg]][[aa]]$data$shifted_clean_data_Fsub <- pluriform_power[[gg]][[aa]]$data$shifted_clean_data[fi, 
                       , , , drop = FALSE]
                   }
                 }
-            }
-            return(pluriform_power)
-        }), deps = c("repository", "analysis_groups", "analysis_settings",
-        "baselined_power", "trial_outliers_list"), cue = targets::tar_cue("thorough"),
-        pattern = NULL, iteration = "list"), build_overall_tf_data = targets::tar_target_raw(name = "overall_tf_data",
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(pluriform_power)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "pluriform_power", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = "user-defined-r", 
+            target_export = "pluriform_power", target_expr = quote({
+                {
+                  options(future.globals.maxSize = 12 * 1024^3)
+                  epoch_event_types = get_available_events(repository$epoch$columns)
+                  baselined_power_data <- subset(baselined_power, 
+                    Electrode ~ Electrode %in% requested_electrodes)
+                  pluriform_power <- raveio::lapply_async(analysis_groups, 
+                    callback = function(x) {
+                      paste("[build_pluriform_power] working on:", 
+                        x$label, "data")
+                    }, FUN = function(ag) {
+                      sapply(analysis_settings_clean, function(as) {
+                        p <- get_pluriform_power(baselined_data = baselined_power_data, 
+                          trial_indices = ag$trials, events = repository$epoch$table, 
+                          epoch_event_types = epoch_event_types, 
+                          trial_outliers_list = unlist(trial_outliers_list), 
+                          event_of_interest = as$event, sample_rate = repository$subject$power_sample_rate)
+                        list(data = p, settings = as, outliers = trial_outliers_list)
+                      }, simplify = FALSE, USE.NAMES = TRUE)
+                    })
+                  for (gg in seq_along(pluriform_power)) {
+                    for (aa in seq_along(pluriform_power[[gg]])) {
+                      fi <- as.numeric(dimnames(pluriform_power[[gg]][[aa]]$data$shifted_data)$Frequency) %within% 
+                        unlist(pluriform_power[[gg]][[aa]]$settings$frequency)
+                      pluriform_power[[gg]][[aa]]$data$shifted_data_Fsub <- pluriform_power[[gg]][[aa]]$data$shifted_data[fi, 
+                        , , , drop = FALSE]
+                      pluriform_power[[gg]][[aa]]$data$shifted_clean_data_Fsub <- pluriform_power[[gg]][[aa]]$data$shifted_clean_data[fi, 
+                        , , , drop = FALSE]
+                    }
+                  }
+                }
+                pluriform_power
+            }), target_depends = c("repository", "baselined_power", 
+            "requested_electrodes", "analysis_groups", "analysis_settings_clean", 
+            "trial_outliers_list")), deps = c("repository", "baselined_power", 
+        "requested_electrodes", "analysis_groups", "analysis_settings_clean", 
+        "trial_outliers_list"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), build_overall_tf_data = targets::tar_target_raw(name = "by_frequency_over_time_data", 
         command = quote({
-            {
-                build_tfd <- function(dd, trial_groups, settings) {
-                  res <- list(data = ravetools::collapse(dd,
-                    keep = 2:1), xlab = "Time (s)", ylab = "Frequency",
-                    zlab = "Mean " %&% baseline_settings$unit_of_analysis)
-                  res$x = as.numeric(dimnames(dd)$Time)
-                  res$y = as.numeric(dimnames(dd)$Frequency)
-                  res$N = dim(dd)[4L]
-                  res$name = trial_groups$label
-                  res$settings = settings
-                  if (isTRUE(settings$censor_info$enabled)) {
+            .__target_expr__. <- quote({
+                build_data <- function(data, analysis_settings, 
+                  condition_group, baseline_settings, ...) {
+                  dn <- dimnames(data)
+                  stopifnot(c("Time", "Frequency") == names(dn)[2:1])
+                  res <- list(data = raveio::collapse2(data, 
+                    keep = 2:1, method = "mean"), x = as.numeric(dn$Time), 
+                    y = as.numeric(dn$Frequency), xlab = "Time (s)", 
+                    ylab = "Frequency", zlab = "Mean " %&% baseline_settings$unit_of_analysis)
+                  if (isTRUE(analysis_settings$censor_info$enabled)) {
                     ti = res$x %within% settings$censor_info$window
                     res$range <- range(res$data[!ti, ])
                   } else {
@@ -260,57 +669,130 @@ rm(._._env_._.)
                   }
                   return(res)
                 }
-                overall_tf_data <- mapply(function(pp, ag) {
-                  if (length(unique(sapply(pp, function(pi) pi$settings$event))) ==
-                    1) {
-                    .settings = list(A = pp[[1]]$settings)
-                    for (ii in seq_along(pp[-1])) {
-                      .settings[[LETTERS[ii + 1]]] = pp[[ii +
-                        1]]$settings
+                by_frequency_over_time_data <- data_builder(pluriform_power = pluriform_power, 
+                  condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                  build_data, data_type = "shifted_clean_data")
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(by_frequency_over_time_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "by_frequency_over_time_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "by_frequency_over_time_data", target_expr = quote({
+                {
+                  build_data <- function(data, analysis_settings, 
+                    condition_group, baseline_settings, ...) {
+                    dn <- dimnames(data)
+                    stopifnot(c("Time", "Frequency") == names(dn)[2:1])
+                    res <- list(data = raveio::collapse2(data, 
+                      keep = 2:1, method = "mean"), x = as.numeric(dn$Time), 
+                      y = as.numeric(dn$Frequency), xlab = "Time (s)", 
+                      ylab = "Frequency", zlab = "Mean " %&% 
+                        baseline_settings$unit_of_analysis)
+                    if (isTRUE(analysis_settings$censor_info$enabled)) {
+                      ti = res$x %within% settings$censor_info$window
+                      res$range <- range(res$data[!ti, ])
+                    } else {
+                      res$range <- range(res$data)
                     }
-                    names(.settings) <- names(pp)
-                    build_tfd(dd = pp[[1]]$data$shifted_clean_data,
-                      trial_groups = ag, settings = .settings)
-                  } else {
-                    sapply(pp, function(ppa) {
-                      build_tfd(ppa$data$shifted_clean_data,
-                        trial_groups = ag, ppa$settings)
-                    }, simplify = FALSE, USE.NAMES = TRUE)
+                    return(res)
                   }
-                }, pluriform_power, analysis_groups, SIMPLIFY = FALSE)
-            }
-            return(overall_tf_data)
-        }), deps = c("baseline_settings", "pluriform_power",
-        "analysis_groups"), cue = targets::tar_cue("thorough"),
-        pattern = NULL, iteration = "list"), build_tf_correlation_data = targets::tar_target_raw(name = "tf_correlation_data",
-        command = quote({
-            {
-                if (length(analysis_settings) == 1) {
-                  tf_correlation_data <- vector("list", length = length(overall_tf_data))
-                  for (ii in seq_along(tf_correlation_data)) {
-                    d <- pluriform_power[[ii]][[1]]$data$shifted_clean_data
-                    tm <- as.numeric(dimnames(d)$Time)
-                    ti <- tm %within% unlist(pluriform_power[[ii]][[1]]$settings$time)
-                    if (isTRUE(pluriform_power[[ii]][[1]]$settings$censor_info$enabled)) {
-                      ti = ti & (tm %within% unlist(pluriform_power[[ii]][[1]]$settings$censor_info$window))
-                    }
-                    stopifnot(c("Frequency", "Time") == names(dimnames(d))[1:2])
-                    d_collapsed <- ravetools::collapse(d[, ti,
-                      , , drop = FALSE], keep = c(2, 1))
-                    tf_correlation_data[[ii]] <- list(data = cor(d_collapsed),
-                      xlab = "", ylab = "", zlab = "Pearson correlation",
-                      x = as.numeric(dimnames(d)[[1]]), y = as.numeric(dimnames(d)[[1]]))
-                  }
-                } else {
-                  stop(">1 analysis not yet support for tf_correlation_data")
+                  by_frequency_over_time_data <- data_builder(pluriform_power = pluriform_power, 
+                    condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                    build_data, data_type = "shifted_clean_data")
                 }
-            }
-            return(tf_correlation_data)
-        }), deps = c("analysis_settings", "overall_tf_data",
-        "pluriform_power"), cue = targets::tar_cue("thorough"),
-        pattern = NULL, iteration = "list"), build_by_trial_tf_data = targets::tar_target_raw(name = "by_trial_tf_data",
+                by_frequency_over_time_data
+            }), target_depends = c("pluriform_power", "analysis_groups", 
+            "baseline_settings")), deps = c("pluriform_power", 
+        "analysis_groups", "baseline_settings"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), build_tf_correlation_data = targets::tar_target_raw(name = "by_frequency_correlation_data", 
         command = quote({
-            {
+            .__target_expr__. <- quote({
+                build_data <- function(data, analysis_settings, 
+                  condition_group, baseline_settings, ...) {
+                  dn <- dimnames(data)
+                  tm <- as.numeric(dn$Time)
+                  ti <- tm %within% analysis_settings$time
+                  if (isTRUE(analysis_settings$censor_info$enabled)) {
+                    ti = ti & !(tm %within% analysis_settings$censor_info$window)
+                  }
+                  rawdata <- ravetools::collapse(data[, ti, , 
+                    , drop = FALSE], keep = c(3, 1))
+                  res <- list(data = cor(rawdata), xlab = "Frequency", 
+                    ylab = "Frequency", zlab = "Pearson correlation across trials", 
+                    x = as.numeric(dn$Frequency), y = as.numeric(dn$Frequency), 
+                    rawdata <- rawdata)
+                  res$range = range(res$data)
+                  return(res)
+                }
+                by_frequency_correlation_data <- data_builder(pluriform_power = pluriform_power, 
+                  condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                  build_data, data_type = "shifted_clean_data")
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(by_frequency_correlation_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "by_frequency_correlation_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "by_frequency_correlation_data", 
+            target_expr = quote({
+                {
+                  build_data <- function(data, analysis_settings, 
+                    condition_group, baseline_settings, ...) {
+                    dn <- dimnames(data)
+                    tm <- as.numeric(dn$Time)
+                    ti <- tm %within% analysis_settings$time
+                    if (isTRUE(analysis_settings$censor_info$enabled)) {
+                      ti = ti & !(tm %within% analysis_settings$censor_info$window)
+                    }
+                    rawdata <- ravetools::collapse(data[, ti, 
+                      , , drop = FALSE], keep = c(3, 1))
+                    res <- list(data = cor(rawdata), xlab = "Frequency", 
+                      ylab = "Frequency", zlab = "Pearson correlation across trials", 
+                      x = as.numeric(dn$Frequency), y = as.numeric(dn$Frequency), 
+                      rawdata <- rawdata)
+                    res$range = range(res$data)
+                    return(res)
+                  }
+                  by_frequency_correlation_data <- data_builder(pluriform_power = pluriform_power, 
+                    condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                    build_data, data_type = "shifted_clean_data")
+                }
+                by_frequency_correlation_data
+            }), target_depends = c("pluriform_power", "analysis_groups", 
+            "baseline_settings")), deps = c("pluriform_power", 
+        "analysis_groups", "baseline_settings"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), plot_bfcd = targets::tar_target_raw(name = "plot_bfcd_success", 
+        command = quote({
+            .__target_expr__. <- quote({
+                plot_bfcd_success = FALSE
+                plot_bfcd_success = TRUE
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(plot_bfcd_success)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "plot_bfcd_success", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "plot_bfcd_success", target_expr = quote({
+                {
+                  plot_bfcd_success = FALSE
+                  plot_bfcd_success = TRUE
+                }
+                plot_bfcd_success
+            }), target_depends = character(0)), deps = character(0), 
+        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"), 
+    build_by_trial_tf_data = targets::tar_target_raw(name = "by_trial_tf_data", 
+        command = quote({
+            .__target_expr__. <- quote({
                 build_data <- function(dd, settings) {
                   to_keep <- sapply(c("Time", "Trial"), which.equal, 
                     names(dimnames(dd)))
@@ -340,89 +822,272 @@ rm(._._env_._.)
                     }, simplify = FALSE, USE.NAMES = TRUE)
                   }
                 })
-            }
-            return(by_trial_tf_data)
-        }), deps = c("baseline_settings", "pluriform_power"),
-        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"),
-    build_by_electrode_tf_data = targets::tar_target_raw(name = "by_electrode_tf_data",
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(by_trial_tf_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "by_trial_tf_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "by_trial_tf_data", target_expr = quote({
+                {
+                  build_data <- function(dd, settings) {
+                    to_keep <- sapply(c("Time", "Trial"), which.equal, 
+                      names(dimnames(dd)))
+                    res <- list(data = ravetools::collapse(dd, 
+                      keep = to_keep), xlab = "Time (s)", ylab = "Original Trial #", 
+                      zlab = "Mean " %&% baseline_settings$unit_of_analysis)
+                    res[c("x", "y")] <- dimnames(dd)[to_keep] %>% 
+                      lapply(as.numeric)
+                    res$N = dim(dd)[4L]
+                    if (isTRUE(settings$censor_info$enabled)) {
+                      ti = res$x %within% settings$censor_info$window
+                      res$range <- range(res$data[!ti, ])
+                    } else {
+                      res$range <- range(res$data)
+                    }
+                    return(res)
+                  }
+                  by_trial_tf_data <- lapply(pluriform_power, 
+                    function(pp) {
+                      if (all(1 == length(table(sapply(pp, function(pi) pi$settings$event))), 
+                        1 == length(table(sapply(pp, function(pi) str_collapse(pi$settings$frequency)))))) {
+                        build_data(pp[[1]]$data$shifted_data_Fsub, 
+                          pp[[1]]$settings)
+                      } else {
+                        sapply(pp, function(ppa) {
+                          build_data(ppa$data$shifted_data_Fsub, 
+                            ppa$settings)
+                        }, simplify = FALSE, USE.NAMES = TRUE)
+                      }
+                    })
+                }
+                by_trial_tf_data
+            }), target_depends = c("baseline_settings", "pluriform_power"
+            )), deps = c("baseline_settings", "pluriform_power"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
+        iteration = "list"), build_over_time_by_electrode_data = targets::tar_target_raw(name = "over_time_by_electrode_data", 
         command = quote({
-            {
-                build_data <- function(dd, settings) {
-                  to_keep <- sapply(c("Time", "Electrode"), which.equal,
-                    names(dimnames(dd)))
-                  res <- list(data = ravetools::collapse(dd,
-                    keep = to_keep), xlab = "Time (s)", ylab = "Electrode #",
-                    zlab = "Mean " %&% baseline_settings$unit_of_analysis)
-                  res[c("x", "y")] <- dimnames(dd)[to_keep] %>%
+            .__target_expr__. <- quote({
+                build_data <- function(data, analysis_settings, 
+                  condition_group, baseline_settings, ...) {
+                  dm <- dimnames(data)
+                  to_keep <- sapply(c("Time", "Electrode"), which.equal, 
+                    names(dm))
+                  res <- list(data = ravetools::collapse(data, 
+                    keep = to_keep), xlab = "Time (s)", ylab = "Electrode #", 
+                    zlab = "Mean " %&% baseline_settings$unit_of_analysis, 
+                    condition_group = condition_group$label, 
+                    electrodes = as.integer(dm$Electrode), subject_code = subject_code)
+                  res[c("x", "y")] <- dimnames(data)[to_keep] %>% 
                     lapply(as.numeric)
-                  res$N = length(dimnames(dd)$Trial)
-                  if (isTRUE(settings$censor_info$enabled)) {
-                    ti = res$x %within% settings$censor_info$window
+                  res$N = length(dm$Trial)
+                  if (isTRUE(analysis_settings$censor_info$enabled)) {
+                    ti = res$x %within% analysis_settings$censor_info$window
                     res$range <- range(res$data[!ti, ])
                   } else {
                     res$range <- range(res$data)
                   }
                   return(res)
                 }
-                by_electrode_tf_data <- lapply(pluriform_power,
-                  function(pp) {
-                    if (length(pp) == 1 || all(1 == length(table(sapply(pp,
-                      function(pi) pi$settings$event))), 1 ==
-                      length(table(sapply(pp, function(pi) str_collapse(pi$settings$frequency)))))) {
-                      build_data(dd = pp[[1]]$data$shifted_clean_data_Fsub,
-                        settings = pp[[1]]$settings)
+                over_time_by_electrode_data <- data_builder(pluriform_power = pluriform_power, 
+                  condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                  build_data)
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(over_time_by_electrode_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "over_time_by_electrode_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "over_time_by_electrode_data", target_expr = quote({
+                {
+                  build_data <- function(data, analysis_settings, 
+                    condition_group, baseline_settings, ...) {
+                    dm <- dimnames(data)
+                    to_keep <- sapply(c("Time", "Electrode"), 
+                      which.equal, names(dm))
+                    res <- list(data = ravetools::collapse(data, 
+                      keep = to_keep), xlab = "Time (s)", ylab = "Electrode #", 
+                      zlab = "Mean " %&% baseline_settings$unit_of_analysis, 
+                      condition_group = condition_group$label, 
+                      electrodes = as.integer(dm$Electrode), 
+                      subject_code = subject_code)
+                    res[c("x", "y")] <- dimnames(data)[to_keep] %>% 
+                      lapply(as.numeric)
+                    res$N = length(dm$Trial)
+                    if (isTRUE(analysis_settings$censor_info$enabled)) {
+                      ti = res$x %within% analysis_settings$censor_info$window
+                      res$range <- range(res$data[!ti, ])
                     } else {
-                      sapply(pp, function(ppa) {
-                        build_data(ppa$data$shifted_clean_data_Fsub,
-                          ppa$settings)
-                      }, simplify = FALSE, USE.NAMES = TRUE)
+                      res$range <- range(res$data)
                     }
-                  })
-            }
-            return(by_electrode_tf_data)
-        }), deps = c("baseline_settings", "pluriform_power"),
-        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"),
-    build_over_time_data = targets::tar_target_raw(name = "over_time_data",
+                    return(res)
+                  }
+                  over_time_by_electrode_data <- data_builder(pluriform_power = pluriform_power, 
+                    condition_group = analysis_groups, baseline_settings = baseline_settings, 
+                    build_data)
+                }
+                over_time_by_electrode_data
+            }), target_depends = c("subject_code", "pluriform_power", 
+            "analysis_groups", "baseline_settings")), deps = c("subject_code", 
+        "pluriform_power", "analysis_groups", "baseline_settings"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
+        iteration = "list"), plot_over_time_by_electrode_data_data = targets::tar_target_raw(name = "betfd_success", 
         command = quote({
-            {
+            .__target_expr__. <- quote({
+                betfd_success <- tryCatch({
+                  draw_many_heat_maps(over_time_by_electrode_data)
+                  TRUE
+                }, error = function(e) {
+                  e
+                })
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(betfd_success)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "betfd_success", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "betfd_success", target_expr = quote({
+                {
+                  betfd_success <- tryCatch({
+                    draw_many_heat_maps(over_time_by_electrode_data)
+                    TRUE
+                  }, error = function(e) {
+                    e
+                  })
+                }
+                betfd_success
+            }), target_depends = "over_time_by_electrode_data"), 
+        deps = "over_time_by_electrode_data", cue = targets::tar_cue("always"), 
+        pattern = NULL, iteration = "list"), build_over_time_by_condition_data = targets::tar_target_raw(name = "over_time_by_condition_data", 
+        command = quote({
+            .__target_expr__. <- quote({
                 build_data <- function(dd, settings) {
                   to_keep <- sapply(c("Time", "Electrode"), which.equal, 
                     names(dimnames(dd)))
                   res <- list(data = ravetools::collapse(dd, 
                     keep = to_keep), xlab = "Time (s)", ylab = "Mean " %&% 
                     baseline_settings$unit_of_analysis, zlab = NA)
-                  res$data <- cbind(.rowMeans(res$data, nrow(res$data),
-                    ncol(res$data)), sqrt(diag(fastcov2(t(res$data)))/ncol(res$data)))
+                  res$data <- cbind(.rowMeans(res$data, nrow(res$data), 
+                    ncol(res$data)), sqrt(diag(dipsaus::fastcov2(t(res$data)))/ncol(res$data)))
+                  ind <- is.nan(res$data[, 2]) | !is.finite(res$data[, 
+                    2])
+                  if (length(ind) > 0) {
+                    res$data[ind, 2] = 0
+                  }
                   res$x <- as.numeric(dimnames(dd)$Time)
                   res$y <- NA
                   res$N = length(dimnames(dd)$Electrode)
                   if (isTRUE(settings$censor_info$enabled)) {
                     ti = res$x %within% settings$censor_info$window
-                    res$range <- range(plus_minus(res$data[!ti,
+                    res$range <- range(rutabaga::plus_minus(res$data[!ti, 
                       ]))
                   } else {
                     res$range <- range(rutabaga::plus_minus(res$data))
                   }
+                  res$electrodes = dimnames(dd)$Electrode
+                  res$settings = settings
                   return(res)
                 }
-                over_time_data <- lapply(pluriform_power, function(pp) {
-                  if (length(pp) == 1 || all(1 == length(table(sapply(pp,
-                    function(pi) pi$settings$event))), 1 == length(table(sapply(pp,
-                    function(pi) str_collapse(pi$settings$frequency)))))) {
-                    build_data(pp[[1]]$data$shifted_clean_data_Fsub,
-                      pp[[1]]$settings)
-                  } else {
+                over_time_by_condition_data <- lapply(pluriform_power, 
+                  function(pp) {
                     sapply(pp, function(ppa) {
-                      build_data(ppa$data$shifted_clean_data_Fsub,
-                        ppa$settings)
+                      build_data(dd = ppa$data$shifted_clean_data_Fsub, 
+                        settings = ppa$settings)
                     }, simplify = FALSE, USE.NAMES = TRUE)
+                  })
+                for (ii in seq_along(over_time_by_condition_data)) {
+                  for (jj in seq_along(over_time_by_condition_data[[ii]])) {
+                    over_time_by_condition_data[[ii]][[jj]]$data_label = names(over_time_by_condition_data)[[ii]]
+                    over_time_by_condition_data[[ii]][[jj]]$time_window_label = names(over_time_by_condition_data[[ii]])[[jj]]
                   }
-                })
-            }
-            return(over_time_data)
-        }), deps = c("baseline_settings", "pluriform_power"),
-        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"),
-    build_scatter_bar_data = targets::tar_target_raw(name = "scatter_bar_data",
+                }
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(over_time_by_condition_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "over_time_by_condition_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "over_time_by_condition_data", target_expr = quote({
+                {
+                  build_data <- function(dd, settings) {
+                    to_keep <- sapply(c("Time", "Electrode"), 
+                      which.equal, names(dimnames(dd)))
+                    res <- list(data = ravetools::collapse(dd, 
+                      keep = to_keep), xlab = "Time (s)", ylab = "Mean " %&% 
+                      baseline_settings$unit_of_analysis, zlab = NA)
+                    res$data <- cbind(.rowMeans(res$data, nrow(res$data), 
+                      ncol(res$data)), sqrt(diag(dipsaus::fastcov2(t(res$data)))/ncol(res$data)))
+                    ind <- is.nan(res$data[, 2]) | !is.finite(res$data[, 
+                      2])
+                    if (length(ind) > 0) {
+                      res$data[ind, 2] = 0
+                    }
+                    res$x <- as.numeric(dimnames(dd)$Time)
+                    res$y <- NA
+                    res$N = length(dimnames(dd)$Electrode)
+                    if (isTRUE(settings$censor_info$enabled)) {
+                      ti = res$x %within% settings$censor_info$window
+                      res$range <- range(rutabaga::plus_minus(res$data[!ti, 
+                        ]))
+                    } else {
+                      res$range <- range(rutabaga::plus_minus(res$data))
+                    }
+                    res$electrodes = dimnames(dd)$Electrode
+                    res$settings = settings
+                    return(res)
+                  }
+                  over_time_by_condition_data <- lapply(pluriform_power, 
+                    function(pp) {
+                      sapply(pp, function(ppa) {
+                        build_data(dd = ppa$data$shifted_clean_data_Fsub, 
+                          settings = ppa$settings)
+                      }, simplify = FALSE, USE.NAMES = TRUE)
+                    })
+                  for (ii in seq_along(over_time_by_condition_data)) {
+                    for (jj in seq_along(over_time_by_condition_data[[ii]])) {
+                      over_time_by_condition_data[[ii]][[jj]]$data_label = names(over_time_by_condition_data)[[ii]]
+                      over_time_by_condition_data[[ii]][[jj]]$time_window_label = names(over_time_by_condition_data[[ii]])[[jj]]
+                    }
+                  }
+                }
+                over_time_by_condition_data
+            }), target_depends = c("baseline_settings", "pluriform_power"
+            )), deps = c("baseline_settings", "pluriform_power"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
+        iteration = "list"), plot_over_time_data = targets::tar_target_raw(name = "plot_over_time_by_condition_result", 
+        command = quote({
+            .__target_expr__. <- quote({
+                plot_over_time_by_condition_result = TRUE
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(plot_over_time_by_condition_result)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "plot_over_time_by_condition_result", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "plot_over_time_by_condition_result", 
+            target_expr = quote({
+                {
+                  plot_over_time_by_condition_result = TRUE
+                }
+                plot_over_time_by_condition_result
+            }), target_depends = character(0)), deps = character(0), 
+        cue = targets::tar_cue("always"), pattern = NULL, iteration = "list"), 
+    build_scatter_bar_data = targets::tar_target_raw(name = "scatter_bar_data", 
         command = quote({
             .__target_expr__. <- quote({
                 build_data <- function(dd, settings) {
@@ -445,32 +1110,1188 @@ rm(._._env_._.)
                   res$N = length(dimnames(dd)$Trial)
                   return(res)
                 }
-                scatter_bar_data <- lapply(pluriform_power, function(pp) {
-                  sapply(pp, function(ppa) {
-                    build_data(ppa$data$shifted_clean_data_Fsub,
-                      ppa$settings)
-                  }, simplify = FALSE, USE.NAMES = TRUE)
-                })
-            }
-            return(scatter_bar_data)
-        }), deps = c("baseline_settings", "pluriform_power"),
-        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"),
-    build_analysis_data = targets::tar_target_raw(name = "analysis_data",
+                scatter_bar_data = FALSE
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(scatter_bar_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "scatter_bar_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "scatter_bar_data", target_expr = quote({
+                {
+                  build_data <- function(dd, settings) {
+                    dm <- dimnames(dd)
+                    to_keep <- which.equal("Trial", names(dm))
+                    stopifnot(which.equal("Time", names(dm)) == 
+                      2)
+                    t_ind <- as.numeric(dm$Time) %within% unlist(settings$time)
+                    if (isTRUE(settings$censor_info$enabled)) {
+                      t_ind = t_ind & !(as.numeric(dm$Time) %within% 
+                        unlist(settings$censor_info$window))
+                    }
+                    res <- list(data = ravetools::collapse(dd[, 
+                      t_ind, , , drop = FALSE], keep = to_keep), 
+                      xlab = "Group", ylab = "Mean " %&% baseline_settings$unit_of_analysis, 
+                      zlab = NA)
+                    res$range <- range(res$data)
+                    res$x <- NA
+                    res$y <- NA
+                    res$N = length(dimnames(dd)$Trial)
+                    return(res)
+                  }
+                  scatter_bar_data = FALSE
+                }
+                scatter_bar_data
+            }), target_depends = "baseline_settings"), deps = "baseline_settings", 
+        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"), 
+    build_analysis_data = targets::tar_target_raw(name = "analysis_data", 
         command = quote({
-            {
-                has_data <- which(sapply(analysis_groups, `[[`,
+            .__target_expr__. <- quote({
+                has_data <- which(sapply(analysis_groups, `[[`, 
                   "has_trials"))
                 analysis_data <- list()
                 analysis_data$datatype <- baseline_settings$unit_of_analysis
-            }
-            return(analysis_data)
-        }), deps = c("analysis_groups", "baseline_settings"),
-        cue = targets::tar_cue("thorough"), pattern = NULL, iteration = "list"),
-    build_omnibus_results = targets::tar_target_raw(name = "omnibus_results",
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(analysis_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "analysis_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "analysis_data", target_expr = quote({
+                {
+                  has_data <- which(sapply(analysis_groups, `[[`, 
+                    "has_trials"))
+                  analysis_data <- list()
+                  analysis_data$datatype <- baseline_settings$unit_of_analysis
+                }
+                analysis_data
+            }), target_depends = c("analysis_groups", "baseline_settings"
+            )), deps = c("analysis_groups", "baseline_settings"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
+        iteration = "list"), build_over_time_by_electrode_dataframe = targets::tar_target_raw(name = "over_time_by_electrode_dataframe", 
         command = quote({
-            {
-                omnibus_results <- 1
-            }
-            return(omnibus_results)
-        }), deps = character(0), cue = targets::tar_cue("thorough"),
-        pattern = NULL, iteration = "list"))
+            .__target_expr__. <- quote({
+                over_time_by_electrode_dataframe <- NULL
+                raveio::power_baseline(repository, baseline_windows = baseline_settings$window, 
+                  method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                  units = get_baseline_scope(baseline_settings$scope), 
+                  signal_type = "LFP", electrodes = repository$electrode_list)
+                non_empty_groups <- which(rutabaga::get_list_elements(analysis_groups, 
+                  "has_trials"))
+                by_condition_group <- raveio::lapply_async(analysis_groups, 
+                  callback = function(x) {
+                    paste("[build_over_time_by_electrode_dataframe] working on:", 
+                      x$label, "data")
+                  }, FUN = function(ag) {
+                    res <- lapply(analysis_settings_clean, function(as) {
+                      fi <- repository$frequency %within% as$frequency
+                      p <- get_pluriform_power(baselined_data = repository$power$baselined[fi, 
+                        , , , drop = FALSE], trial_indices = ag$trials, 
+                        events = repository$epoch$table, epoch_event_types = get_available_events(repository$epoch$columns), 
+                        trial_outliers_list = unlist(trial_outliers_list), 
+                        event_of_interest = as$event, final_data_only = TRUE, 
+                        sample_rate = repository$subject$power_sample_rate)
+                      stopifnot(names(dimnames(p)) == c("Frequency", 
+                        "Time", "Trial", "Electrode"))
+                      enames = as.integer(dimnames(p)$Electrode)
+                      times = as.numeric(dimnames(p)$Time)
+                      m <- ravetools::collapse(p[drop = FALSE], 
+                        keep = c(4, 2))
+                      df <- data.frame(reshape2::melt(m, value.name = paste(sep = "_", 
+                        as$label, ag$label)))
+                      names(df)[1:2] = c("Electrode", "Time")
+                      df$Electrode = enames[df$Electrode]
+                      df$Time = times[df$Time]
+                      return(df)
+                    })
+                    if (length(res) == 1) {
+                      return(res[[1]])
+                    }
+                    merged_res <- res[[1]]
+                    for (ri in seq_along(res)[-1]) {
+                      merged_res = merge(merged_res, res[[ri]], 
+                        all = TRUE)
+                    }
+                    return(merged_res)
+                  })
+                over_time_by_electrode_dataframe <- by_condition_group[[1]]
+                if (length(by_condition_group) > 1) {
+                  for (ii in seq_along(by_condition_group)[-1]) {
+                    over_time_by_electrode_dataframe = merge(over_time_by_electrode_dataframe, 
+                      by_condition_group[[ii]], all = TRUE)
+                  }
+                }
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(over_time_by_electrode_dataframe)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "over_time_by_electrode_dataframe", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "over_time_by_electrode_dataframe", 
+            target_expr = quote({
+                {
+                  over_time_by_electrode_dataframe <- NULL
+                  raveio::power_baseline(repository, baseline_windows = baseline_settings$window, 
+                    method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                    units = get_baseline_scope(baseline_settings$scope), 
+                    signal_type = "LFP", electrodes = repository$electrode_list)
+                  non_empty_groups <- which(rutabaga::get_list_elements(analysis_groups, 
+                    "has_trials"))
+                  by_condition_group <- raveio::lapply_async(analysis_groups, 
+                    callback = function(x) {
+                      paste("[build_over_time_by_electrode_dataframe] working on:", 
+                        x$label, "data")
+                    }, FUN = function(ag) {
+                      res <- lapply(analysis_settings_clean, 
+                        function(as) {
+                          fi <- repository$frequency %within% 
+                            as$frequency
+                          p <- get_pluriform_power(baselined_data = repository$power$baselined[fi, 
+                            , , , drop = FALSE], trial_indices = ag$trials, 
+                            events = repository$epoch$table, 
+                            epoch_event_types = get_available_events(repository$epoch$columns), 
+                            trial_outliers_list = unlist(trial_outliers_list), 
+                            event_of_interest = as$event, final_data_only = TRUE, 
+                            sample_rate = repository$subject$power_sample_rate)
+                          stopifnot(names(dimnames(p)) == c("Frequency", 
+                            "Time", "Trial", "Electrode"))
+                          enames = as.integer(dimnames(p)$Electrode)
+                          times = as.numeric(dimnames(p)$Time)
+                          m <- ravetools::collapse(p[drop = FALSE], 
+                            keep = c(4, 2))
+                          df <- data.frame(reshape2::melt(m, 
+                            value.name = paste(sep = "_", as$label, 
+                              ag$label)))
+                          names(df)[1:2] = c("Electrode", "Time")
+                          df$Electrode = enames[df$Electrode]
+                          df$Time = times[df$Time]
+                          return(df)
+                        })
+                      if (length(res) == 1) {
+                        return(res[[1]])
+                      }
+                      merged_res <- res[[1]]
+                      for (ri in seq_along(res)[-1]) {
+                        merged_res = merge(merged_res, res[[ri]], 
+                          all = TRUE)
+                      }
+                      return(merged_res)
+                    })
+                  over_time_by_electrode_dataframe <- by_condition_group[[1]]
+                  if (length(by_condition_group) > 1) {
+                    for (ii in seq_along(by_condition_group)[-1]) {
+                      over_time_by_electrode_dataframe = merge(over_time_by_electrode_dataframe, 
+                        by_condition_group[[ii]], all = TRUE)
+                    }
+                  }
+                }
+                over_time_by_electrode_dataframe
+            }), target_depends = c("repository", "baseline_settings", 
+            "analysis_groups", "analysis_settings_clean", "trial_outliers_list"
+            )), deps = c("repository", "baseline_settings", "analysis_groups", 
+        "analysis_settings_clean", "trial_outliers_list"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), build_over_time_by_trial = targets::tar_target_raw(name = "over_time_by_trial_data", 
+        command = quote({
+            .__target_expr__. <- quote({
+                build_data <- function(data, analysis_settings, 
+                  condition_group, baseline_settings, ...) {
+                  dm <- dimnames(data)
+                  to_keep <- c(which.equal("Time", names(dm)), 
+                    which.equal("Trial", names(dm)))
+                  res <- list(data = ravetools::collapse(data[, 
+                    drop = FALSE], keep = to_keep), x = as.numeric(dm$Time), 
+                    xlab = "Time", ylab = "Trial (sorted by condition)", 
+                    zlab = sprintf("Mean %s", baseline_settings$unit_of_analysis))
+                  res$range <- range(res$data)
+                  cnds <- condition_group$conditions
+                  tt <- condition_group$trials
+                  res$y <- trial_details[as.character(tt), condition_variable]
+                  cf <- factor(res$y, levels = cnds)
+                  ord = order(cf, tt)
+                  res$y <- res$y[ord]
+                  res$trial_number = tt[ord]
+                  res$is_outlier = tt[ord] %in% trial_outliers_list
+                  res$data <- res$data[, ord]
+                  return(res)
+                }
+                over_time_by_trial_data <- data_builder(pluriform_power, 
+                  condition_groups = analysis_groups, baseline_settings = baseline_settings, 
+                  BUILDER_FUN = build_data, data_type = "shifted_data_Fsub")
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(over_time_by_trial_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "over_time_by_trial_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "over_time_by_trial_data", target_expr = quote({
+                {
+                  build_data <- function(data, analysis_settings, 
+                    condition_group, baseline_settings, ...) {
+                    dm <- dimnames(data)
+                    to_keep <- c(which.equal("Time", names(dm)), 
+                      which.equal("Trial", names(dm)))
+                    res <- list(data = ravetools::collapse(data[, 
+                      drop = FALSE], keep = to_keep), x = as.numeric(dm$Time), 
+                      xlab = "Time", ylab = "Trial (sorted by condition)", 
+                      zlab = sprintf("Mean %s", baseline_settings$unit_of_analysis))
+                    res$range <- range(res$data)
+                    cnds <- condition_group$conditions
+                    tt <- condition_group$trials
+                    res$y <- trial_details[as.character(tt), 
+                      condition_variable]
+                    cf <- factor(res$y, levels = cnds)
+                    ord = order(cf, tt)
+                    res$y <- res$y[ord]
+                    res$trial_number = tt[ord]
+                    res$is_outlier = tt[ord] %in% trial_outliers_list
+                    res$data <- res$data[, ord]
+                    return(res)
+                  }
+                  over_time_by_trial_data <- data_builder(pluriform_power, 
+                    condition_groups = analysis_groups, baseline_settings = baseline_settings, 
+                    BUILDER_FUN = build_data, data_type = "shifted_data_Fsub")
+                }
+                over_time_by_trial_data
+            }), target_depends = c("trial_details", "condition_variable", 
+            "trial_outliers_list", "pluriform_power", "analysis_groups", 
+            "baseline_settings")), deps = c("trial_details", 
+        "condition_variable", "trial_outliers_list", "pluriform_power", 
+        "analysis_groups", "baseline_settings"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), build_internal_omnibus_results = targets::tar_target_raw(name = "internal_omnibus_results", 
+        command = quote({
+            .__target_expr__. <- quote({
+                options(future.globals.maxSize = 16 * 1024^3)
+                raveio::power_baseline(repository, baseline_windows = baseline_settings$window, 
+                  method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                  units = get_baseline_scope(baseline_settings$scope), 
+                  signal_type = "LFP", electrodes = repository$electrode_list)
+                non_empty_groups <- which(rutabaga::get_list_elements(analysis_groups, 
+                  "has_trials"))
+                by_condition_group <- raveio::lapply_async(x = analysis_groups[non_empty_groups], 
+                  function(ag) {
+                    lapply(analysis_settings_clean, function(as) {
+                      fi <- repository$frequency %within% as$frequency
+                      all_p <- get_pluriform_power(baselined_data = repository$power$baselined[fi, 
+                        , , , drop = FALSE], trial_indices = ag$trials, 
+                        events = repository$epoch$table, epoch_event_types = get_available_events(repository$epoch$columns), 
+                        trial_outliers_list = unlist(trial_outliers_list), 
+                        event_of_interest = as$event, sample_rate = repository$subject$power_sample_rate)
+                      p <- all_p$shifted_data
+                      ti = as.numeric(dimnames(p)$Time) %within% 
+                        as$time
+                      stopifnot(names(dimnames(p))[2] == "Time")
+                      m <- ravetools::collapse(p[, ti, , , drop = FALSE], 
+                        keep = 3:4)
+                      mse <- apply(m, 2, rutabaga::m_se)
+                      ts = mse[1, ]/mse[2, ]
+                      collapsed <- cbind(mse[1, ], ts, 2 * pt(abs(ts), 
+                        df = nrow(m) - 1, lower.tail = F))
+                      enames = dimnames(p)$Electrode
+                      rownames(collapsed) = enames
+                      colnames(collapsed) = paste0(c("m", "t", 
+                        "p"), "(", ag$label, "; ", as$label, 
+                        ")")
+                      trial_column <- rep(dimnames(p)$Trial, 
+                        times = ncol(m))
+                      by_trial <- data.frame(y = c(m), Electrode = rep(as.numeric(enames), 
+                        each = nrow(m)), Trial = trial_column, 
+                        is_clean = !(trial_column %in% trial_outliers_list), 
+                        Factor1 = ag$label, Time = "t" %&% str_collapse(as$time, 
+                          "-"), Freq = "f" %&% str_collapse(as$frequency, 
+                          "-"), Event = as$event, AnalysisLabel = as$label)
+                      return(list(df = by_trial, collapsed = collapsed))
+                    })
+                  })
+                all_data <- rutabaga::rbind_list(sapply(by_condition_group, 
+                  rutabaga::get_list_elements, "df", use_sapply = FALSE))
+                if (isTRUE(enable_second_condition_groupings)) {
+                  meta_table <- attr(analysis_groups, "meta")
+                  stopifnot(is.data.frame(meta_table))
+                  all_data$Factor1 = NULL
+                  all_data %<>% merge(meta_table, by = c("Trial"))
+                  all_data$Factor1Factor2 = mapply(paste, all_data$Factor1, 
+                    all_data$Factor2, sep = ".")
+                  all_data$Factor1Factor2 %<>% factor(levels = names(analysis_groups))
+                } else {
+                  if (!is.factor(all_data$Factor1)) {
+                    all_data$Factor1 %<>% factor(levels = names(by_condition_group))
+                  }
+                }
+                if (!is.null(all_data$AnalysisLabel)) {
+                  all_data$AnalysisLabel %<>% factor(levels = names(analysis_settings_clean))
+                }
+                all_data_clean <- subset(all_data, is_clean)
+                get_factor_length <- function(x) length(unique(all_data_clean[[x]]))
+                repeated_factors <- "AnalysisLabel"
+                unrepeated_factors <- c("Factor1", "Factor2")
+                factor_lengths <- sapply(c(repeated_factors, 
+                  unrepeated_factors), get_factor_length)
+                fixed_effects <- names(factor_lengths[factor_lengths > 
+                  1])
+                formula_str <- paste0("y ~ ", str_collapse(fixed_effects, 
+                  "*"))
+                if (formula_str == "y ~ ") formula_str = "y ~ 1"
+                has_re <- any(repeated_factors %in% fixed_effects)
+                stat_fun <- stats::lm
+                if (has_re) {
+                  formula_str %<>% paste("+ (1|Trial)")
+                  stat_fun <- lmerTest::lmer
+                }
+                formula_frm = as.formula(formula_str)
+                run_stats <- function(el) {
+                  mod <- stat_fun(formula_frm, data = el)
+                  if (length(coef(mod)) == 1 && class(mod) != 
+                    "lmerModLmerTest") {
+                    lsm <- emmeans::emmeans(mod, specs = "1")
+                    summ <- summary(lsm, infer = TRUE)
+                    emm = matrix(unlist(t(summ[c("emmean", "t.ratio", 
+                      "p.value")])))
+                    lbls <- as.character(summ[[1]])
+                    rownames(emm) = c(outer(c("m(", "t(", "p("), 
+                      lbls, paste0)) %&% ")"
+                    res <- emm
+                  } else {
+                    lsm <- emmeans::emmeans(mod, as.formula("pairwise ~" %&% 
+                      str_collapse(fixed_effects, "*")))
+                    summ <- summary(lsm$emmeans, infer = TRUE)
+                    emm = matrix(unlist(t(summ[c("emmean", "t.ratio", 
+                      "p.value")])))
+                    lbls <- apply(summ[, fixed_effects, drop = FALSE], 
+                      1, str_collapse, by = " ")
+                    rownames(emm) = c(outer(c("m(", "t(", "p("), 
+                      lbls, paste0)) %&% ")"
+                    cntr = summary(lsm, adjust = "fdr")$contrasts
+                    cmat = matrix(unlist(t(cntr[, c("estimate", 
+                      "t.ratio", "p.value")])))
+                    rownames(cmat) = c(t(sapply(c("m(", "t(", 
+                      "p_fdr("), paste0, cntr$contrast))) %&% 
+                      ")"
+                    tmp <- summary(emmeans::emmeans(mod, specs = "1"), 
+                      infer = TRUE)
+                    tmp.emm = matrix(unlist(t(tmp[c("emmean", 
+                      "t.ratio", "p.value")])))
+                    tmp.lbls <- as.character(tmp[[1]])
+                    rownames(tmp.emm) = c(outer(c("m(", "t(", 
+                      "p("), tmp.lbls, paste0)) %&% ")"
+                    res <- rbind(tmp.emm, emm, cmat)
+                  }
+                  colnames(res) = el$Electrode[1]
+                  return(res)
+                }
+                stats <- all_data_clean %>% split((.)$Electrode) %>% 
+                  raveio::lapply_async(function(el) {
+                    if (var(el$y) < 1e-12) {
+                      return(NULL)
+                    }
+                    run_stats(el)
+                  }) %>% rutabaga::cbind_list()
+                attr(stats, "electrode_labels") = repository$electrode_table$Label
+                all_data %<>% merge(repository$epoch$table[, 
+                  c("Block", "Trial")], sort = FALSE)
+                internal_omnibus_results = list(data_with_outliers = all_data, 
+                  data = all_data_clean, stats = stats)
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(internal_omnibus_results)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "internal_omnibus_results", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "internal_omnibus_results", target_expr = quote({
+                {
+                  options(future.globals.maxSize = 16 * 1024^3)
+                  raveio::power_baseline(repository, baseline_windows = baseline_settings$window, 
+                    method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                    units = get_baseline_scope(baseline_settings$scope), 
+                    signal_type = "LFP", electrodes = repository$electrode_list)
+                  non_empty_groups <- which(rutabaga::get_list_elements(analysis_groups, 
+                    "has_trials"))
+                  by_condition_group <- raveio::lapply_async(x = analysis_groups[non_empty_groups], 
+                    function(ag) {
+                      lapply(analysis_settings_clean, function(as) {
+                        fi <- repository$frequency %within% as$frequency
+                        all_p <- get_pluriform_power(baselined_data = repository$power$baselined[fi, 
+                          , , , drop = FALSE], trial_indices = ag$trials, 
+                          events = repository$epoch$table, epoch_event_types = get_available_events(repository$epoch$columns), 
+                          trial_outliers_list = unlist(trial_outliers_list), 
+                          event_of_interest = as$event, sample_rate = repository$subject$power_sample_rate)
+                        p <- all_p$shifted_data
+                        ti = as.numeric(dimnames(p)$Time) %within% 
+                          as$time
+                        stopifnot(names(dimnames(p))[2] == "Time")
+                        m <- ravetools::collapse(p[, ti, , , 
+                          drop = FALSE], keep = 3:4)
+                        mse <- apply(m, 2, rutabaga::m_se)
+                        ts = mse[1, ]/mse[2, ]
+                        collapsed <- cbind(mse[1, ], ts, 2 * 
+                          pt(abs(ts), df = nrow(m) - 1, lower.tail = F))
+                        enames = dimnames(p)$Electrode
+                        rownames(collapsed) = enames
+                        colnames(collapsed) = paste0(c("m", "t", 
+                          "p"), "(", ag$label, "; ", as$label, 
+                          ")")
+                        trial_column <- rep(dimnames(p)$Trial, 
+                          times = ncol(m))
+                        by_trial <- data.frame(y = c(m), Electrode = rep(as.numeric(enames), 
+                          each = nrow(m)), Trial = trial_column, 
+                          is_clean = !(trial_column %in% trial_outliers_list), 
+                          Factor1 = ag$label, Time = "t" %&% 
+                            str_collapse(as$time, "-"), Freq = "f" %&% 
+                            str_collapse(as$frequency, "-"), 
+                          Event = as$event, AnalysisLabel = as$label)
+                        return(list(df = by_trial, collapsed = collapsed))
+                      })
+                    })
+                  all_data <- rutabaga::rbind_list(sapply(by_condition_group, 
+                    rutabaga::get_list_elements, "df", use_sapply = FALSE))
+                  if (isTRUE(enable_second_condition_groupings)) {
+                    meta_table <- attr(analysis_groups, "meta")
+                    stopifnot(is.data.frame(meta_table))
+                    all_data$Factor1 = NULL
+                    all_data %<>% merge(meta_table, by = c("Trial"))
+                    all_data$Factor1Factor2 = mapply(paste, all_data$Factor1, 
+                      all_data$Factor2, sep = ".")
+                    all_data$Factor1Factor2 %<>% factor(levels = names(analysis_groups))
+                  } else {
+                    if (!is.factor(all_data$Factor1)) {
+                      all_data$Factor1 %<>% factor(levels = names(by_condition_group))
+                    }
+                  }
+                  if (!is.null(all_data$AnalysisLabel)) {
+                    all_data$AnalysisLabel %<>% factor(levels = names(analysis_settings_clean))
+                  }
+                  all_data_clean <- subset(all_data, is_clean)
+                  get_factor_length <- function(x) length(unique(all_data_clean[[x]]))
+                  repeated_factors <- "AnalysisLabel"
+                  unrepeated_factors <- c("Factor1", "Factor2")
+                  factor_lengths <- sapply(c(repeated_factors, 
+                    unrepeated_factors), get_factor_length)
+                  fixed_effects <- names(factor_lengths[factor_lengths > 
+                    1])
+                  formula_str <- paste0("y ~ ", str_collapse(fixed_effects, 
+                    "*"))
+                  if (formula_str == "y ~ ") formula_str = "y ~ 1"
+                  has_re <- any(repeated_factors %in% fixed_effects)
+                  stat_fun <- stats::lm
+                  if (has_re) {
+                    formula_str %<>% paste("+ (1|Trial)")
+                    stat_fun <- lmerTest::lmer
+                  }
+                  formula_frm = as.formula(formula_str)
+                  run_stats <- function(el) {
+                    mod <- stat_fun(formula_frm, data = el)
+                    if (length(coef(mod)) == 1 && class(mod) != 
+                      "lmerModLmerTest") {
+                      lsm <- emmeans::emmeans(mod, specs = "1")
+                      summ <- summary(lsm, infer = TRUE)
+                      emm = matrix(unlist(t(summ[c("emmean", 
+                        "t.ratio", "p.value")])))
+                      lbls <- as.character(summ[[1]])
+                      rownames(emm) = c(outer(c("m(", "t(", "p("), 
+                        lbls, paste0)) %&% ")"
+                      res <- emm
+                    } else {
+                      lsm <- emmeans::emmeans(mod, as.formula("pairwise ~" %&% 
+                        str_collapse(fixed_effects, "*")))
+                      summ <- summary(lsm$emmeans, infer = TRUE)
+                      emm = matrix(unlist(t(summ[c("emmean", 
+                        "t.ratio", "p.value")])))
+                      lbls <- apply(summ[, fixed_effects, drop = FALSE], 
+                        1, str_collapse, by = " ")
+                      rownames(emm) = c(outer(c("m(", "t(", "p("), 
+                        lbls, paste0)) %&% ")"
+                      cntr = summary(lsm, adjust = "fdr")$contrasts
+                      cmat = matrix(unlist(t(cntr[, c("estimate", 
+                        "t.ratio", "p.value")])))
+                      rownames(cmat) = c(t(sapply(c("m(", "t(", 
+                        "p_fdr("), paste0, cntr$contrast))) %&% 
+                        ")"
+                      tmp <- summary(emmeans::emmeans(mod, specs = "1"), 
+                        infer = TRUE)
+                      tmp.emm = matrix(unlist(t(tmp[c("emmean", 
+                        "t.ratio", "p.value")])))
+                      tmp.lbls <- as.character(tmp[[1]])
+                      rownames(tmp.emm) = c(outer(c("m(", "t(", 
+                        "p("), tmp.lbls, paste0)) %&% ")"
+                      res <- rbind(tmp.emm, emm, cmat)
+                    }
+                    colnames(res) = el$Electrode[1]
+                    return(res)
+                  }
+                  stats <- all_data_clean %>% split((.)$Electrode) %>% 
+                    raveio::lapply_async(function(el) {
+                      if (var(el$y) < 1e-12) {
+                        return(NULL)
+                      }
+                      run_stats(el)
+                    }) %>% rutabaga::cbind_list()
+                  attr(stats, "electrode_labels") = repository$electrode_table$Label
+                  all_data %<>% merge(repository$epoch$table[, 
+                    c("Block", "Trial")], sort = FALSE)
+                  internal_omnibus_results = list(data_with_outliers = all_data, 
+                    data = all_data_clean, stats = stats)
+                }
+                internal_omnibus_results
+            }), target_depends = c("repository", "baseline_settings", 
+            "analysis_groups", "analysis_settings_clean", "trial_outliers_list", 
+            "enable_second_condition_groupings")), deps = c("repository", 
+        "baseline_settings", "analysis_groups", "analysis_settings_clean", 
+        "trial_outliers_list", "enable_second_condition_groupings"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
+        iteration = "list"), build_omnibus_results = targets::tar_target_raw(name = "omnibus_results", 
+        command = quote({
+            .__target_expr__. <- quote({
+                omnibus_results = internal_omnibus_results
+                rn <- "currently_selected"
+                while (rn %in% names(omnibus_results$data)) {
+                  rn <- "PWR_EXPLR_" %&% rn
+                }
+                omnibus_results$data[[rn]] = omnibus_results$data$Electrode %in% 
+                  requested_electrodes
+                omnibus_results$data_with_outliers[[rn]] = omnibus_results$data_with_outliers$Electrode %in% 
+                  requested_electrodes
+                rn <- "currently_selected"
+                while (rn %in% rownames(omnibus_results$stats)) {
+                  rn = "RAVE_" %&% rn
+                }
+                val = matrix(nrow = 1, as.integer(colnames(omnibus_results$stats) %in% 
+                  as.character(requested_electrodes)), dimnames = list(rn))
+                omnibus_results$stats %<>% rbind(val)
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(omnibus_results)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "omnibus_results", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "omnibus_results", target_expr = quote({
+                {
+                  omnibus_results = internal_omnibus_results
+                  rn <- "currently_selected"
+                  while (rn %in% names(omnibus_results$data)) {
+                    rn <- "PWR_EXPLR_" %&% rn
+                  }
+                  omnibus_results$data[[rn]] = omnibus_results$data$Electrode %in% 
+                    requested_electrodes
+                  omnibus_results$data_with_outliers[[rn]] = omnibus_results$data_with_outliers$Electrode %in% 
+                    requested_electrodes
+                  rn <- "currently_selected"
+                  while (rn %in% rownames(omnibus_results$stats)) {
+                    rn = "RAVE_" %&% rn
+                  }
+                  val = matrix(nrow = 1, as.integer(colnames(omnibus_results$stats) %in% 
+                    as.character(requested_electrodes)), dimnames = list(rn))
+                  omnibus_results$stats %<>% rbind(val)
+                }
+                omnibus_results
+            }), target_depends = c("internal_omnibus_results", 
+            "requested_electrodes")), deps = c("internal_omnibus_results", 
+        "requested_electrodes"), cue = targets::tar_cue("thorough"), 
+        pattern = NULL, iteration = "list"), build_across_electrode_statistics = targets::tar_target_raw(name = "across_electrode_statistics", 
+        command = quote({
+            .__target_expr__. <- quote({
+                require(data.table)
+                .datatable.aware = TRUE
+                dd <- subset(omnibus_results$data, currently_selected)
+                emmeans::emm_options(lmer.df = "satterthwaite")
+                ravedash::logger("top of BAES", calc_delta = TRUE)
+                rand_effects <- c("Block", "Electrode") %>% intersect(names(dd))
+                fixed_effects <- c("Factor1", "Factor2", "AnalysisLabel") %>% 
+                  intersect(names(dd))
+                for (ff in c(rand_effects, fixed_effects)) {
+                  dd[[ff]] %<>% as.factor
+                }
+                fe <- names(which(sapply(dd[fixed_effects], nlevels) > 
+                  1))
+                re <- names(which(sapply(dd[rand_effects], nlevels) > 
+                  1))
+                if ("AnalysisLabel" %in% fe) {
+                  if ("Block" %in% re) {
+                    if ("Electrode" %in% re) {
+                      re[which(re == "Block")] = "Block/Trial"
+                    }
+                  } else {
+                    re %<>% c("Trial")
+                  }
+                }
+                re_str = NULL
+                if (length(re) > 0) {
+                  re_str <- paste(collapse = "+", sapply(re, 
+                    function(x) sprintf("(1|%s)", x)))
+                }
+                dt <- data.table::as.data.table(dd)
+                condition_means <- dt[, list(y = mean(y), sd = sd(y), 
+                  se = rutabaga:::se(y), n = .N), keyby = fe]
+                ravedash::logger("got condition means", calc_delta = TRUE)
+                fe <- paste0(fe, collapse = "*")
+                if (!nzchar(fe)) {
+                  fe <- "1"
+                }
+                frm <- as.formula(paste("y ~", paste(c(fe, re_str), 
+                  collapse = " + ")))
+                FUN <- ifelse(is.null(re_str), stats::lm, lme4::lmer)
+                mod <- do.call(FUN, list(formula = frm, data = dd))
+                ravedash::logger("built linear model, starting post hoc tests", 
+                  calc_delta = TRUE)
+                em <- emmeans::emmeans(mod, as.formula(sprintf(" ~ %s", 
+                  fe)), infer = c(F, T))
+                ravedash::logger("Got emm", calc_delta = TRUE)
+                pairwise <- emmeans::contrast(em, "pairwise")
+                ravedash::logger("Got pairwise contrasts", calc_delta = TRUE)
+                stratified_contrasts <- NULL
+                if (length(fe) > 1) {
+                  stratified_contrasts <- get_stratified_contrasts(em)
+                }
+                itx_contrasts <- NULL
+                if (length(fe) == 2) {
+                  nm <- paste0(fe, collapse = "_")
+                  itx_contrasts <- list(emmeans::contrast(em, 
+                    interaction = c("pairwise", "pairwise"))) %>% 
+                    setNames(nm)
+                }
+                if (length(fe) > 2) {
+                  fe_combn <- combn(fe, 2, simplify = FALSE)
+                  itx_contrasts <- sapply(fe_combn, function(groups) {
+                    emmeans::contrast(em, interaction = c("pairwise", 
+                      "pairwise"), by = fe[!fe %in% groups])
+                  }) %>% setNames(sapply(fe_combn, paste0, collapse = "."))
+                }
+                ravedash::logger("Got other contrasts", calc_delta = TRUE)
+                .aov <- car::Anova(mod, type = ifelse(fe[1] == 
+                  "1", "III", "II"))
+                ravedash::logger("Got ANOVA", calc_delta = TRUE)
+                across_electrode_statistics <- list(condition_means = condition_means, 
+                  model = mod, model_type = class(mod)[1], aov = .aov, 
+                  emmeans = em, pairwise_contrasts = pairwise, 
+                  fixed_effects = fe, random_effects = re, stratified_contrasts = stratified_contrasts, 
+                  itx_contrasts = itx_contrasts, trials_not_included = sort(trial_outliers_list))
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(across_electrode_statistics)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "across_electrode_statistics", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "across_electrode_statistics", target_expr = quote({
+                {
+                  require(data.table)
+                  .datatable.aware = TRUE
+                  dd <- subset(omnibus_results$data, currently_selected)
+                  emmeans::emm_options(lmer.df = "satterthwaite")
+                  ravedash::logger("top of BAES", calc_delta = TRUE)
+                  rand_effects <- c("Block", "Electrode") %>% 
+                    intersect(names(dd))
+                  fixed_effects <- c("Factor1", "Factor2", "AnalysisLabel") %>% 
+                    intersect(names(dd))
+                  for (ff in c(rand_effects, fixed_effects)) {
+                    dd[[ff]] %<>% as.factor
+                  }
+                  fe <- names(which(sapply(dd[fixed_effects], 
+                    nlevels) > 1))
+                  re <- names(which(sapply(dd[rand_effects], 
+                    nlevels) > 1))
+                  if ("AnalysisLabel" %in% fe) {
+                    if ("Block" %in% re) {
+                      if ("Electrode" %in% re) {
+                        re[which(re == "Block")] = "Block/Trial"
+                      }
+                    } else {
+                      re %<>% c("Trial")
+                    }
+                  }
+                  re_str = NULL
+                  if (length(re) > 0) {
+                    re_str <- paste(collapse = "+", sapply(re, 
+                      function(x) sprintf("(1|%s)", x)))
+                  }
+                  dt <- data.table::as.data.table(dd)
+                  condition_means <- dt[, list(y = mean(y), sd = sd(y), 
+                    se = rutabaga:::se(y), n = .N), keyby = fe]
+                  ravedash::logger("got condition means", calc_delta = TRUE)
+                  fe <- paste0(fe, collapse = "*")
+                  if (!nzchar(fe)) {
+                    fe <- "1"
+                  }
+                  frm <- as.formula(paste("y ~", paste(c(fe, 
+                    re_str), collapse = " + ")))
+                  FUN <- ifelse(is.null(re_str), stats::lm, lme4::lmer)
+                  mod <- do.call(FUN, list(formula = frm, data = dd))
+                  ravedash::logger("built linear model, starting post hoc tests", 
+                    calc_delta = TRUE)
+                  em <- emmeans::emmeans(mod, as.formula(sprintf(" ~ %s", 
+                    fe)), infer = c(F, T))
+                  ravedash::logger("Got emm", calc_delta = TRUE)
+                  pairwise <- emmeans::contrast(em, "pairwise")
+                  ravedash::logger("Got pairwise contrasts", 
+                    calc_delta = TRUE)
+                  stratified_contrasts <- NULL
+                  if (length(fe) > 1) {
+                    stratified_contrasts <- get_stratified_contrasts(em)
+                  }
+                  itx_contrasts <- NULL
+                  if (length(fe) == 2) {
+                    nm <- paste0(fe, collapse = "_")
+                    itx_contrasts <- list(emmeans::contrast(em, 
+                      interaction = c("pairwise", "pairwise"))) %>% 
+                      setNames(nm)
+                  }
+                  if (length(fe) > 2) {
+                    fe_combn <- combn(fe, 2, simplify = FALSE)
+                    itx_contrasts <- sapply(fe_combn, function(groups) {
+                      emmeans::contrast(em, interaction = c("pairwise", 
+                        "pairwise"), by = fe[!fe %in% groups])
+                    }) %>% setNames(sapply(fe_combn, paste0, 
+                      collapse = "."))
+                  }
+                  ravedash::logger("Got other contrasts", calc_delta = TRUE)
+                  .aov <- car::Anova(mod, type = ifelse(fe[1] == 
+                    "1", "III", "II"))
+                  ravedash::logger("Got ANOVA", calc_delta = TRUE)
+                  across_electrode_statistics <- list(condition_means = condition_means, 
+                    model = mod, model_type = class(mod)[1], 
+                    aov = .aov, emmeans = em, pairwise_contrasts = pairwise, 
+                    fixed_effects = fe, random_effects = re, 
+                    stratified_contrasts = stratified_contrasts, 
+                    itx_contrasts = itx_contrasts, trials_not_included = sort(trial_outliers_list))
+                }
+                across_electrode_statistics
+            }), target_depends = c("omnibus_results", "trial_outliers_list"
+            )), deps = c("omnibus_results", "trial_outliers_list"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
+        iteration = "list"), build_by_trial_electrode_similarity_data = targets::tar_target_raw(name = "by_trial_electrode_similarity_data", 
+        command = quote({
+            .__target_expr__. <- quote({
+                dd <- omnibus_results$data
+                by_trial_electrode_similarity_data <- NULL
+                if (enable_second_condition_groupings) {
+                } else {
+                  by_trial_electrode_similarity_data <- lapply(split(dd, 
+                    list(dd$AnalysisLabel, dd$Factor1)), function(bb) {
+                    bb <- bb[order(bb$Electrode, bb$Trial), ]
+                    mat <- matrix(c(bb$y), nrow = length(unique(bb$Trial)), 
+                      dimnames = list(NULL, unique(bb$Electrode)))
+                    cor(mat)
+                  })
+                }
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(by_trial_electrode_similarity_data)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "by_trial_electrode_similarity_data", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "by_trial_electrode_similarity_data", 
+            target_expr = quote({
+                {
+                  dd <- omnibus_results$data
+                  by_trial_electrode_similarity_data <- NULL
+                  if (enable_second_condition_groupings) {
+                  } else {
+                    by_trial_electrode_similarity_data <- lapply(split(dd, 
+                      list(dd$AnalysisLabel, dd$Factor1)), function(bb) {
+                      bb <- bb[order(bb$Electrode, bb$Trial), 
+                        ]
+                      mat <- matrix(c(bb$y), nrow = length(unique(bb$Trial)), 
+                        dimnames = list(NULL, unique(bb$Electrode)))
+                      cor(mat)
+                    })
+                  }
+                }
+                by_trial_electrode_similarity_data
+            }), target_depends = c("omnibus_results", "enable_second_condition_groupings"
+            )), deps = c("omnibus_results", "enable_second_condition_groupings"
+        ), cue = targets::tar_cue("thorough"), pattern = NULL, 
+        iteration = "list"), build_data_for_export = targets::tar_target_raw(name = "data_for_export", 
+        command = quote({
+            .__target_expr__. <- quote({
+                warning("Overlapping time/frequency windows will not be coded properly in the export file")
+                if (getOption("knit_rave_pipelines", default = FALSE)) {
+                  list2env(list(electrodes_to_export = repository$power$dimnames$Electrode[1]), 
+                    envir = environment())
+                } else {
+                }
+                prog <- shidashi::shiny_progress("Building export data", 
+                  max = 4, shiny_auto_close = TRUE)
+                data_for_export = FALSE
+                electrodes_to_keep <- dipsaus::parse_svec(electrodes_to_export, 
+                  sep = ",|;", connect = ":-")
+                electrodes_to_keep %<>% remove_from_arr(repository$power$dimnames$Electrode, 
+                  `%in%`, negate = TRUE)
+                if (electrodes_to_export_roi_name != "none") {
+                  v = if (electrodes_to_export_roi_name == "Custom ROI") {
+                  } else {
+                    electrodes_to_export_roi_name
+                  }
+                  lbls <- subset(repository$electrode_table, 
+                    Electrode %in% electrodes_to_keep, select = v, 
+                    drop = TRUE)
+                  electrodes_to_keep = electrodes_to_keep[lbls %in% 
+                    electrodes_to_export_roi_categories]
+                }
+                if (!length(electrodes_to_keep)) {
+                  stop("No electrodes were found passing all selection criteria")
+                }
+                prog$inc("Baseline data [export loop]")
+                raveio::power_baseline(repository, baseline_windows = baseline_settings$window, 
+                  method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                  units = get_baseline_scope(baseline_settings$scope), 
+                  signal_type = "LFP", electrodes = electrodes_to_keep)
+                tensors <- lapply(analysis_settings_clean, function(asc) {
+                  ravedash::logger("Working on ", asc$label)
+                  current_tensor = subset(repository$power$baselined, 
+                    Electrode ~ Electrode %in% electrodes_to_keep)
+                  tet <- trial_export_types()
+                  trials_to_keep = repository$power$dimnames$Trial
+                  if (trials_to_export %in% c(tet$RAW_GRP, tet$CLP_GRP, 
+                    tet$CLP_CND)) {
+                    trials_to_keep <- sort(unique(c(unlist(sapply(analysis_groups, 
+                      `[[`, "trials")))))
+                  }
+                  shifted_tensor <- get_pluriform_power(baselined_data = current_tensor, 
+                    trial_indices = trials_to_keep, events = repository$epoch$table, 
+                    epoch_event_types = get_available_events(repository$epoch$columns), 
+                    trial_outliers_list = unlist(trial_outliers_list), 
+                    event_of_interest = asc$event, sample_rate = repository$subject$power_sample_rate, 
+                    final_data_only = TRUE)
+                  dn = lapply(dimnames(shifted_tensor), as.numeric)
+                  if (trials_to_export == tet$CLP_GRP) {
+                    with_trials <- which_have_trials(analysis_groups)
+                    by_group <- sapply(analysis_groups[with_trials], 
+                      function(ag) {
+                        ind <- (dn$Trial %in% ag$trials)
+                        ravetools::collapse(shifted_tensor[, 
+                          , ind, , drop = FALSE], keep = c(1, 
+                          2, 4))
+                      })
+                    shifted_tensor = tensor_reshape(mat = by_group, 
+                      orig_dim = dim(shifted_tensor), pivot = 3)
+                    dn$Trial = unname(sapply(analysis_groups[with_trials], 
+                      `[[`, "label"))
+                    dimnames(shifted_tensor) = dn
+                  }
+                  attr_TrialLabel = subset(repository$epoch$table, 
+                    Trial %in% dn$Trial, select = c("Trial", 
+                      condition_variable)) %>% data.table::setorder("Trial")
+                  attr_TrialLabel$OrigCondition = attr_TrialLabel[[condition_variable]]
+                  for (ag in which_have_trials(analysis_groups)) {
+                    ind = attr_TrialLabel$Trial %in% analysis_groups[[ag]]$trials
+                    attr_TrialLabel$Condition[ind] = names(analysis_groups)[ag]
+                  }
+                  tmet <- time_export_types()
+                  if (times_to_export %in% c(tmet$CLP_AWO, tmet$RAW_AWO)) {
+                    ind <- dn$Time %within% asc$time
+                    shifted_tensor = shifted_tensor[, ind, , 
+                      , drop = FALSE]
+                    dn$Time = as.numeric(dimnames(shifted_tensor)$Time)
+                  }
+                  if (times_to_export == tmet$CLP_AWO) {
+                    tmp = ravetools::collapse(shifted_tensor, 
+                      keep = c(1, 3:4))
+                    dim(tmp) = c(dim(tmp), 1)
+                    shifted_tensor <- aperm(tmp, c(1, 4, 2, 3))
+                    dn$Time = asc$label
+                    dimnames(shifted_tensor) = dn
+                  }
+                  fet = frequency_export_types()
+                  if (frequencies_to_export %in% c(fet$CLP_AWO, 
+                    fet$RAW_AWO)) {
+                    ff <- dn$Frequency %within% asc$frequency
+                    shifted_tensor = shifted_tensor[ff, , , , 
+                      drop = FALSE]
+                  }
+                  dn$Frequency = as.numeric(dimnames(shifted_tensor)$Frequency)
+                  if (frequencies_to_export == fet$CLP_AWO) {
+                    tmp = ravetools::collapse(shifted_tensor, 
+                      keep = 2:4)
+                    dim(tmp) = c(dim(tmp), 1)
+                    shifted_tensor <- aperm(tmp, c(4, 1:3))
+                    dn$Frequency = asc$label
+                    dimnames(shifted_tensor) = dn
+                  }
+                  if (length(attr_TrialLabel$Condition) == length(dn$Trial) && 
+                    all(0 == (dn$Trial - attr_TrialLabel$Trial))) {
+                    attr(shifted_tensor, "TrialLabel") = attr_TrialLabel$Condition
+                    attr(shifted_tensor, "OrigTrialLabel") = attr_TrialLabel$OrigCondition
+                  } else {
+                    ravedash::logger(level = "warning", "Could not apply trial labels. Length mismatch between labels (", 
+                      nrow(attr_TrialLabel), ") and  trials (", 
+                      length(dn$Trial), "), or trial numbers didn't line up")
+                  }
+                  return(shifted_tensor)
+                })
+                uoa = get_unit_of_analysis_varname(baseline_settings$unit_of_analysis)
+                if (electrode_export_data_type == "tensor") {
+                  data_for_export = mapply(function(tensor, asc) {
+                    dn <- dimnames(tensor)
+                    dn %<>% lapply(function(d) {
+                      nd <- suppressWarnings(as.numeric(d))
+                      if (any(is.na(nd))) return(d)
+                      nd
+                    })
+                    res <- list(data = tensor)
+                    res[names(dn)] = dn
+                    res$unit = uoa
+                    res$baseline_window = baseline_settings$window[[1]]
+                    res$baseline_scope = baseline_settings$scope[[1]]
+                    if (!is.null(attributes(tensor)[["TrialLabel"]])) {
+                      res$TrialLabel = attr(tensor, "TrialLabel")
+                      res$OrigTrialLabel = attr(tensor, "OrigTrialLabel")
+                    }
+                    return(res)
+                  }, tensors, analysis_settings_clean, SIMPLIFY = FALSE)
+                  names(data_for_export) = names(analysis_settings_clean)
+                  data_for_export$data_names = names(data_for_export)
+                  data_for_export$type = "tensor_data"
+                } else {
+                  flat_tables <- mapply(function(tensor, asc) {
+                    tbl <- data.table::as.data.table(reshape2::melt(tensor[drop = FALSE], 
+                      value.name = uoa))
+                    tbl$AnalysisGroup = asc$label
+                    if (!is.null(attributes(tensor)[["TrialLabel"]])) {
+                      df <- data.table::data.table(Trial = as.numeric(dimnames(tensor)$Trial), 
+                        TrialLabel = attributes(tensor)[["TrialLabel"]], 
+                        OrigTrialLabel = attributes(tensor)[["OrigTrialLabel"]])
+                      tbl %<>% merge(df, all.y = FALSE, all.x = TRUE)
+                    }
+                    return(tbl)
+                  }, tensors, analysis_settings_clean, SIMPLIFY = FALSE)
+                  if (!data.table::is.data.table(flat_tables)) {
+                    flat_tables <- rutabaga::rbind_list(flat_tables)
+                  }
+                  flat_tables %<>% lapply(function(x) {
+                    if (is.factor(x)) {
+                      x <- as.character(x)
+                    }
+                    x
+                  }) %>% as.data.frame
+                  all_elecs <- as.integer(unique(sapply(tensors, 
+                    function(tn) dimnames(tn)$Electrode)))
+                  et <- subset(repository$electrode_table, Electrode %in% 
+                    all_elecs)
+                  flat_tables %<>% merge(et)
+                  data_for_export = list(type = "flat_data", 
+                    data_names = "all_data", all_data = list(data = flat_tables), 
+                    metadata = list(unit = uoa, baseline_window = paste0(collapse = ":", 
+                      baseline_settings$window[[1]]), baseline_scope = baseline_settings$scope[[1]]))
+                }
+            })
+            tryCatch({
+                eval(.__target_expr__.)
+                return(data_for_export)
+            }, error = function(e) {
+                asNamespace("raveio")$resolve_pipeline_error(name = "data_for_export", 
+                  condition = e, expr = .__target_expr__.)
+            })
+        }), format = asNamespace("raveio")$target_format_dynamic(name = NULL, 
+            target_export = "data_for_export", target_expr = quote({
+                {
+                  warning("Overlapping time/frequency windows will not be coded properly in the export file")
+                  if (getOption("knit_rave_pipelines", default = FALSE)) {
+                    list2env(list(electrodes_to_export = repository$power$dimnames$Electrode[1]), 
+                      envir = environment())
+                  } else {
+                  }
+                  prog <- shidashi::shiny_progress("Building export data", 
+                    max = 4, shiny_auto_close = TRUE)
+                  data_for_export = FALSE
+                  electrodes_to_keep <- dipsaus::parse_svec(electrodes_to_export, 
+                    sep = ",|;", connect = ":-")
+                  electrodes_to_keep %<>% remove_from_arr(repository$power$dimnames$Electrode, 
+                    `%in%`, negate = TRUE)
+                  if (electrodes_to_export_roi_name != "none") {
+                    v = if (electrodes_to_export_roi_name == 
+                      "Custom ROI") {
+                    } else {
+                      electrodes_to_export_roi_name
+                    }
+                    lbls <- subset(repository$electrode_table, 
+                      Electrode %in% electrodes_to_keep, select = v, 
+                      drop = TRUE)
+                    electrodes_to_keep = electrodes_to_keep[lbls %in% 
+                      electrodes_to_export_roi_categories]
+                  }
+                  if (!length(electrodes_to_keep)) {
+                    stop("No electrodes were found passing all selection criteria")
+                  }
+                  prog$inc("Baseline data [export loop]")
+                  raveio::power_baseline(repository, baseline_windows = baseline_settings$window, 
+                    method = get_unit_of_analysis(baseline_settings$unit_of_analysis), 
+                    units = get_baseline_scope(baseline_settings$scope), 
+                    signal_type = "LFP", electrodes = electrodes_to_keep)
+                  tensors <- lapply(analysis_settings_clean, 
+                    function(asc) {
+                      ravedash::logger("Working on ", asc$label)
+                      current_tensor = subset(repository$power$baselined, 
+                        Electrode ~ Electrode %in% electrodes_to_keep)
+                      tet <- trial_export_types()
+                      trials_to_keep = repository$power$dimnames$Trial
+                      if (trials_to_export %in% c(tet$RAW_GRP, 
+                        tet$CLP_GRP, tet$CLP_CND)) {
+                        trials_to_keep <- sort(unique(c(unlist(sapply(analysis_groups, 
+                          `[[`, "trials")))))
+                      }
+                      shifted_tensor <- get_pluriform_power(baselined_data = current_tensor, 
+                        trial_indices = trials_to_keep, events = repository$epoch$table, 
+                        epoch_event_types = get_available_events(repository$epoch$columns), 
+                        trial_outliers_list = unlist(trial_outliers_list), 
+                        event_of_interest = asc$event, sample_rate = repository$subject$power_sample_rate, 
+                        final_data_only = TRUE)
+                      dn = lapply(dimnames(shifted_tensor), as.numeric)
+                      if (trials_to_export == tet$CLP_GRP) {
+                        with_trials <- which_have_trials(analysis_groups)
+                        by_group <- sapply(analysis_groups[with_trials], 
+                          function(ag) {
+                            ind <- (dn$Trial %in% ag$trials)
+                            ravetools::collapse(shifted_tensor[, 
+                              , ind, , drop = FALSE], keep = c(1, 
+                              2, 4))
+                          })
+                        shifted_tensor = tensor_reshape(mat = by_group, 
+                          orig_dim = dim(shifted_tensor), pivot = 3)
+                        dn$Trial = unname(sapply(analysis_groups[with_trials], 
+                          `[[`, "label"))
+                        dimnames(shifted_tensor) = dn
+                      }
+                      attr_TrialLabel = subset(repository$epoch$table, 
+                        Trial %in% dn$Trial, select = c("Trial", 
+                          condition_variable)) %>% data.table::setorder("Trial")
+                      attr_TrialLabel$OrigCondition = attr_TrialLabel[[condition_variable]]
+                      for (ag in which_have_trials(analysis_groups)) {
+                        ind = attr_TrialLabel$Trial %in% analysis_groups[[ag]]$trials
+                        attr_TrialLabel$Condition[ind] = names(analysis_groups)[ag]
+                      }
+                      tmet <- time_export_types()
+                      if (times_to_export %in% c(tmet$CLP_AWO, 
+                        tmet$RAW_AWO)) {
+                        ind <- dn$Time %within% asc$time
+                        shifted_tensor = shifted_tensor[, ind, 
+                          , , drop = FALSE]
+                        dn$Time = as.numeric(dimnames(shifted_tensor)$Time)
+                      }
+                      if (times_to_export == tmet$CLP_AWO) {
+                        tmp = ravetools::collapse(shifted_tensor, 
+                          keep = c(1, 3:4))
+                        dim(tmp) = c(dim(tmp), 1)
+                        shifted_tensor <- aperm(tmp, c(1, 4, 
+                          2, 3))
+                        dn$Time = asc$label
+                        dimnames(shifted_tensor) = dn
+                      }
+                      fet = frequency_export_types()
+                      if (frequencies_to_export %in% c(fet$CLP_AWO, 
+                        fet$RAW_AWO)) {
+                        ff <- dn$Frequency %within% asc$frequency
+                        shifted_tensor = shifted_tensor[ff, , 
+                          , , drop = FALSE]
+                      }
+                      dn$Frequency = as.numeric(dimnames(shifted_tensor)$Frequency)
+                      if (frequencies_to_export == fet$CLP_AWO) {
+                        tmp = ravetools::collapse(shifted_tensor, 
+                          keep = 2:4)
+                        dim(tmp) = c(dim(tmp), 1)
+                        shifted_tensor <- aperm(tmp, c(4, 1:3))
+                        dn$Frequency = asc$label
+                        dimnames(shifted_tensor) = dn
+                      }
+                      if (length(attr_TrialLabel$Condition) == 
+                        length(dn$Trial) && all(0 == (dn$Trial - 
+                        attr_TrialLabel$Trial))) {
+                        attr(shifted_tensor, "TrialLabel") = attr_TrialLabel$Condition
+                        attr(shifted_tensor, "OrigTrialLabel") = attr_TrialLabel$OrigCondition
+                      } else {
+                        ravedash::logger(level = "warning", "Could not apply trial labels. Length mismatch between labels (", 
+                          nrow(attr_TrialLabel), ") and  trials (", 
+                          length(dn$Trial), "), or trial numbers didn't line up")
+                      }
+                      return(shifted_tensor)
+                    })
+                  uoa = get_unit_of_analysis_varname(baseline_settings$unit_of_analysis)
+                  if (electrode_export_data_type == "tensor") {
+                    data_for_export = mapply(function(tensor, 
+                      asc) {
+                      dn <- dimnames(tensor)
+                      dn %<>% lapply(function(d) {
+                        nd <- suppressWarnings(as.numeric(d))
+                        if (any(is.na(nd))) return(d)
+                        nd
+                      })
+                      res <- list(data = tensor)
+                      res[names(dn)] = dn
+                      res$unit = uoa
+                      res$baseline_window = baseline_settings$window[[1]]
+                      res$baseline_scope = baseline_settings$scope[[1]]
+                      if (!is.null(attributes(tensor)[["TrialLabel"]])) {
+                        res$TrialLabel = attr(tensor, "TrialLabel")
+                        res$OrigTrialLabel = attr(tensor, "OrigTrialLabel")
+                      }
+                      return(res)
+                    }, tensors, analysis_settings_clean, SIMPLIFY = FALSE)
+                    names(data_for_export) = names(analysis_settings_clean)
+                    data_for_export$data_names = names(data_for_export)
+                    data_for_export$type = "tensor_data"
+                  } else {
+                    flat_tables <- mapply(function(tensor, asc) {
+                      tbl <- data.table::as.data.table(reshape2::melt(tensor[drop = FALSE], 
+                        value.name = uoa))
+                      tbl$AnalysisGroup = asc$label
+                      if (!is.null(attributes(tensor)[["TrialLabel"]])) {
+                        df <- data.table::data.table(Trial = as.numeric(dimnames(tensor)$Trial), 
+                          TrialLabel = attributes(tensor)[["TrialLabel"]], 
+                          OrigTrialLabel = attributes(tensor)[["OrigTrialLabel"]])
+                        tbl %<>% merge(df, all.y = FALSE, all.x = TRUE)
+                      }
+                      return(tbl)
+                    }, tensors, analysis_settings_clean, SIMPLIFY = FALSE)
+                    if (!data.table::is.data.table(flat_tables)) {
+                      flat_tables <- rutabaga::rbind_list(flat_tables)
+                    }
+                    flat_tables %<>% lapply(function(x) {
+                      if (is.factor(x)) {
+                        x <- as.character(x)
+                      }
+                      x
+                    }) %>% as.data.frame
+                    all_elecs <- as.integer(unique(sapply(tensors, 
+                      function(tn) dimnames(tn)$Electrode)))
+                    et <- subset(repository$electrode_table, 
+                      Electrode %in% all_elecs)
+                    flat_tables %<>% merge(et)
+                    data_for_export = list(type = "flat_data", 
+                      data_names = "all_data", all_data = list(data = flat_tables), 
+                      metadata = list(unit = uoa, baseline_window = paste0(collapse = ":", 
+                        baseline_settings$window[[1]]), baseline_scope = baseline_settings$scope[[1]]))
+                  }
+                }
+                data_for_export
+            }), target_depends = c("repository", "electrodes_to_export", 
+            "electrodes_to_export_roi_name", "electrodes_to_export_roi_categories", 
+            "baseline_settings", "analysis_settings_clean", "trials_to_export", 
+            "analysis_groups", "trial_outliers_list", "condition_variable", 
+            "times_to_export", "frequencies_to_export", "electrode_export_data_type"
+            )), deps = c("repository", "electrodes_to_export", 
+        "electrodes_to_export_roi_name", "electrodes_to_export_roi_categories", 
+        "baseline_settings", "analysis_settings_clean", "trials_to_export", 
+        "analysis_groups", "trial_outliers_list", "condition_variable", 
+        "times_to_export", "frequencies_to_export", "electrode_export_data_type"
+        ), cue = targets::tar_cue("always"), pattern = NULL, 
+        iteration = "list"))

--- a/modules/power_explorer/settings.yaml
+++ b/modules/power_explorer/settings.yaml
@@ -4,49 +4,35 @@ trials_to_export: Raw, Only trials used in grouping factors
 times_to_export: Raw, All available times
 frequencies_to_export: Collapsed, Analysis window(s) only
 electrode_export_file_type: HDF5
-trial_outliers_list: '270'
+trial_outliers_list: ~
 time_censor:
   enabled: no
   window:
   - 0.0
   - 1.0
-project_name: demo
-subject_code: DemoSubject
-loaded_electrodes: 13-16,24
-epoch_choice: auditory_onset
+project_name: EMU_NoisyWords
+subject_code: PAV002
+loaded_electrodes: 18-19,79-81
+epoch_choice: UTO_PAV002_5modalities_voao
 epoch_choice__trial_starts: -0.55
-epoch_choice__trial_ends: 3
-reference_name: default
+epoch_choice__trial_ends: 3.0
+reference_name: bipolar
 baseline_settings:
   window:
   - - -0.5
     - 0.0
   scope: Per frequency, trial, and electrode
   unit_of_analysis: '% Change Power'
-analysis_electrodes: '13 '
+analysis_electrodes: 18-19,79-80
 first_condition_groupings:
   '1':
-    label: All Conditions
+    label: Vo
     conditions:
-    - drive_a
-    - drive_av
-    - drive_v
-    - known_a
-    - known_av
-    - known_v
-    - last_a
-    - last_av
-    - last_v
-    - meant_a
-    - meant_av
-    - meant_v
-    - press_AV
+    - V
   '2':
-    label: AV-inc
+    label: A
     conditions:
-    - AdriveVlast
-    - AknownVmeant
-    - AlastVknown
+    - Ac
 second_condition_groupings:
   '1':
     label: ML
@@ -66,10 +52,19 @@ custom_roi_groupings:
 analysis_settings:
   '1':
     label: VisStart
-    event: Trial Onset
+    event: newVisStart
     time:
     - 0
-    - 0.8
+    - 1
+    frequency:
+    - 70
+    - 150
+  '2':
+    label: AudStart
+    event: newAudStart
+    time:
+    - 0
+    - 1
     frequency:
     - 70
     - 150

--- a/modules/power_explorer/settings.yaml
+++ b/modules/power_explorer/settings.yaml
@@ -1,58 +1,77 @@
-analysis_electrodes__category: freesurferlabel
-analysis_settings:
-  '1':
-    label: A-onset BHA
-    event: Trial Onset
-    time:
-    - 0
-    - 0.5
-    frequency:
-    - 70
-    - 126
-baseline_settings:
-  window:
-  - - -1.0
-    - -0.5
-  scope: Per frequency, trial, and electrode
-  unit_of_analysis: '% Change Power'
-electrode_groupings:
-  enabled: no
-  groups:
-    '1':
-      label: STG/S
-      electrodes: 13-14
-    '2':
-      label: Other
-      electrodes: 15-25
-electrodes_list: 13-16,24
-epoch_choice: auditory_onset
-epoch_choice__trial_ends: 2.0
-epoch_choice__trial_starts: -1.0
-first_condition_groupings:
-  '1':
-    label: AOnly
-    conditions:
-    - drive_a
-    - known_a
-    - last_a
-    - meant_a
-  '2':
-    label: AV
-    conditions:
-    - last_av
-    - drive_av
-    - known_av
-    - meant_av
-    - meant_v
-    - press_AV
-project_name: demo
-reference_name: default
-selected_electrodes: '13 '
-subject_name: DemoSubject
-tensor_collapse_method: mean
+electrode_export_data_type: tensor
+electrodes_to_export: ''
+trials_to_export: Raw, Only trials used in grouping factors
+times_to_export: Raw, All available times
+frequencies_to_export: Collapsed, Analysis window(s) only
+electrode_export_file_type: HDF5
+trial_outliers_list: '270'
 time_censor:
   enabled: no
   window:
-  - 0
-  - 1
-trial_outliers_list: ~
+  - 0.0
+  - 1.0
+project_name: demo
+subject_code: DemoSubject
+loaded_electrodes: 13-16,24
+epoch_choice: auditory_onset
+epoch_choice__trial_starts: -0.55
+epoch_choice__trial_ends: 3
+reference_name: default
+baseline_settings:
+  window:
+  - - -0.5
+    - 0.0
+  scope: Per frequency, trial, and electrode
+  unit_of_analysis: '% Change Power'
+analysis_electrodes: '13 '
+first_condition_groupings:
+  '1':
+    label: All Conditions
+    conditions:
+    - drive_a
+    - drive_av
+    - drive_v
+    - known_a
+    - known_av
+    - known_v
+    - last_a
+    - last_av
+    - last_v
+    - meant_a
+    - meant_av
+    - meant_v
+    - press_AV
+  '2':
+    label: AV-inc
+    conditions:
+    - AdriveVlast
+    - AknownVmeant
+    - AlastVknown
+second_condition_groupings:
+  '1':
+    label: ML
+    conditions: []
+  '2':
+    label: VL
+    conditions: []
+enable_second_condition_groupings: no
+condition_variable: Condition
+enable_custom_ROI: no
+custom_roi_type: Filter only
+custom_roi_variable: none
+custom_roi_groupings:
+  '1':
+    label: ''
+    conditions: []
+analysis_settings:
+  '1':
+    label: VisStart
+    event: Trial Onset
+    time:
+    - 0
+    - 0.8
+    frequency:
+    - 70
+    - 150
+electrodes_to_export_roi_name: none
+electrodes_to_export_roi_categories: ~


### PR DESCRIPTION
All changes are in the power explorer module. Added support for forking pipeline data to enable group analysis module to load pipeline objects. Forked pipelines are saved in the users data dir and can be accessed by other modules. Added text to the loader screen clarifying that the trial start times should likely be negative when choose pre/post epoch times.