### PR TITLE
Avoid ignoring shared modules in python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .pyc
 __pycache__
 modules/*/shared/
+!modules/*/py/*
 _rs_job.R
 Rplots.pdf
 .Rhistory*
@@ -13,7 +14,6 @@ node_modules
 modules_\[backup_*\].yaml
 modules/*/main.html
 README.html
-shared
 adhoc
 data
 /app.R


### PR DESCRIPTION
Fixing https://github.com/rave-ieeg/rave-pipelines/issues/26